### PR TITLE
feat(rust): Implement regex engine selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3644,6 +3644,8 @@ dependencies = [
  "serde_json",
  "slotmap",
  "stacker",
+ "strum",
+ "strum_macros",
  "sysinfo",
  "version_check",
 ]

--- a/crates/polars-io/src/cloud/glob.rs
+++ b/crates/polars-io/src/cloud/glob.rs
@@ -6,7 +6,7 @@ use polars_core::error::to_compute_err;
 use polars_error::{PolarsResult, polars_bail};
 use polars_utils::format_pl_smallstr;
 use polars_utils::pl_str::PlSmallStr;
-use regex::Regex;
+use polars_utils::regex_adapter::RegexAdapter;
 use url::Url;
 
 use super::{CloudOptions, parse_url};
@@ -173,7 +173,7 @@ fn full_url(scheme: &str, bucket: &str, key: Path) -> String {
 /// The Cloud list api returns a list of all the file names under a prefix, there is no additional cost of `readdir`.
 pub(crate) struct Matcher {
     prefix: String,
-    re: Option<Regex>,
+    re: Option<RegexAdapter>,
 }
 
 impl Matcher {
@@ -181,7 +181,7 @@ impl Matcher {
     pub(crate) fn new(prefix: String, expansion: Option<&str>) -> PolarsResult<Matcher> {
         // Cloud APIs accept a prefix without any expansion, extract it.
         let re = expansion
-            .map(polars_utils::regex_cache::compile_regex)
+            .map(|exp| polars_utils::regex_cache::compile_regex(exp, Default::default()))
             .transpose()?;
         Ok(Matcher { prefix, re })
     }

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -241,10 +241,11 @@ fn read_config(
 
         for (pattern, key) in keys.iter() {
             if builder.get_config_value(key).is_none() {
-                let reg = polars_utils::regex_cache::compile_regex(pattern).unwrap();
+                let reg =
+                    polars_utils::regex_cache::compile_regex(pattern, Default::default()).unwrap();
                 let cap = reg.captures(content)?;
                 let m = cap.get(1)?;
-                let parsed = m.as_str();
+                let parsed = m;
                 *builder = std::mem::take(builder).with_config(*key, parsed);
             }
         }

--- a/crates/polars-lazy/src/tests/predicate_queries.rs
+++ b/crates/polars-lazy/src/tests/predicate_queries.rs
@@ -47,7 +47,7 @@ fn test_issue_2472() -> PolarsResult<()> {
     let extract = col("group")
         .cast(DataType::String)
         .str()
-        .extract(lit(r"(\d+-){4}(\w+)-"), 2)
+        .extract(lit(r"(\d+-){4}(\w+)-"), 2, Default::default())
         .cast(DataType::Int32)
         .alias("age");
     let predicate = col("age").is_in(lit(Series::new("".into(), [2i32])), false);

--- a/crates/polars-ops/src/chunked_array/strings/extract.rs
+++ b/crates/polars-ops/src/chunked_array/strings/extract.rs
@@ -4,14 +4,13 @@ use std::iter::zip;
 use arrow::array::{Array, StructArray};
 use arrow::array::{MutablePlString, Utf8ViewArray};
 use polars_core::prelude::arity::{try_binary_mut_with_options, try_unary_mut_with_options};
-use regex::Regex;
-
-use super::*;
+use polars_core::prelude::*;
+use polars_utils::regex_adapter::{RegexAdapter, RegexEngine};
 
 #[cfg(feature = "extract_groups")]
 fn extract_groups_array(
     arr: &Utf8ViewArray,
-    reg: &Regex,
+    reg: &RegexAdapter,
     names: &[&str],
     dtype: ArrowDataType,
 ) -> PolarsResult<ArrayRef> {
@@ -19,12 +18,12 @@ fn extract_groups_array(
         .map(|_| MutablePlString::with_capacity(arr.len()))
         .collect::<Vec<_>>();
 
-    let mut locs = reg.capture_locations();
+    let mut buffer = reg.create_locations_buffer();
     for opt_v in arr {
         if let Some(s) = opt_v {
-            if reg.captures_read(&mut locs, s).is_some() {
+            if let Some(caps) = reg.captures_with_buffer(s, &mut buffer) {
                 for (i, builder) in builders.iter_mut().enumerate() {
-                    builder.push(locs.get(i + 1).map(|(start, stop)| &s[start..stop]));
+                    builder.push(caps.get(i + 1));
                 }
                 continue;
             }
@@ -44,8 +43,9 @@ pub(super) fn extract_groups(
     ca: &StringChunked,
     pat: &str,
     dtype: &DataType,
+    engine: RegexEngine,
 ) -> PolarsResult<Series> {
-    let reg = polars_utils::regex_cache::compile_regex(pat)?;
+    let reg = polars_utils::regex_cache::compile_regex(pat, engine)?;
     let n_fields = reg.captures_len();
     if n_fields == 1 {
         return StructChunked::from_series(
@@ -75,45 +75,42 @@ pub(super) fn extract_groups(
 
 fn extract_group_reg_lit(
     arr: &Utf8ViewArray,
-    reg: &Regex,
+    reg: &RegexAdapter,
     group_index: usize,
 ) -> PolarsResult<Utf8ViewArray> {
     let mut builder = MutablePlString::with_capacity(arr.len());
 
-    let mut locs = reg.capture_locations();
+    let mut buffer = reg.create_locations_buffer();
     for opt_v in arr {
         if let Some(s) = opt_v {
-            if reg.captures_read(&mut locs, s).is_some() {
-                builder.push(locs.get(group_index).map(|(start, stop)| &s[start..stop]));
-                continue;
-            }
+            builder.push(reg.get_group_with_buffer(s, group_index, &mut buffer));
+            continue;
         }
 
-        // Push null if either the string is null or there was no match.
+        // Push null if the string is null
         builder.push_null();
     }
 
-    Ok(builder.into())
+    Ok(builder.freeze())
 }
 
 fn extract_group_array_lit(
     s: &str,
     pat: &Utf8ViewArray,
     group_index: usize,
+    engine: RegexEngine,
 ) -> PolarsResult<Utf8ViewArray> {
     let mut builder = MutablePlString::with_capacity(pat.len());
 
     for opt_pat in pat {
         if let Some(pat) = opt_pat {
-            let reg = polars_utils::regex_cache::compile_regex(pat)?;
-            let mut locs = reg.capture_locations();
-            if reg.captures_read(&mut locs, s).is_some() {
-                builder.push(locs.get(group_index).map(|(start, stop)| &s[start..stop]));
-                continue;
-            }
+            let reg = polars_utils::regex_cache::compile_regex(pat, engine)?;
+            let mut buffer = reg.create_locations_buffer();
+            builder.push(reg.get_group_with_buffer(s, group_index, &mut buffer));
+            continue;
         }
 
-        // Push null if either the pat is null or there was no match.
+        // Push null if the pat is null
         builder.push_null();
     }
 
@@ -124,20 +121,16 @@ fn extract_group_binary(
     arr: &Utf8ViewArray,
     pat: &Utf8ViewArray,
     group_index: usize,
+    engine: RegexEngine,
 ) -> PolarsResult<Utf8ViewArray> {
     let mut builder = MutablePlString::with_capacity(arr.len());
 
     for (opt_s, opt_pat) in zip(arr, pat) {
         match (opt_s, opt_pat) {
             (Some(s), Some(pat)) => {
-                let reg = polars_utils::regex_cache::compile_regex(pat)?;
-                let mut locs = reg.capture_locations();
-                if reg.captures_read(&mut locs, s).is_some() {
-                    builder.push(locs.get(group_index).map(|(start, stop)| &s[start..stop]));
-                    continue;
-                }
-                // Push null if there was no match.
-                builder.push_null()
+                let reg = polars_utils::regex_cache::compile_regex(pat, engine)?;
+                let mut buffer = reg.create_locations_buffer();
+                builder.push(reg.get_group_with_buffer(s, group_index, &mut buffer));
             },
             _ => builder.push_null(),
         }
@@ -150,11 +143,12 @@ pub(super) fn extract_group(
     ca: &StringChunked,
     pat: &StringChunked,
     group_index: usize,
+    engine: RegexEngine,
 ) -> PolarsResult<StringChunked> {
     match (ca.len(), pat.len()) {
         (_, 1) => {
             if let Some(pat) = pat.get(0) {
-                let reg = polars_utils::regex_cache::compile_regex(pat)?;
+                let reg = polars_utils::regex_cache::compile_regex(pat, engine)?;
                 try_unary_mut_with_options(ca, |arr| extract_group_reg_lit(arr, &reg, group_index))
             } else {
                 Ok(StringChunked::full_null(ca.name().clone(), ca.len()))
@@ -162,7 +156,9 @@ pub(super) fn extract_group(
         },
         (1, _) => {
             if let Some(s) = ca.get(0) {
-                try_unary_mut_with_options(pat, |pat| extract_group_array_lit(s, pat, group_index))
+                try_unary_mut_with_options(pat, |pat| {
+                    extract_group_array_lit(s, pat, group_index, engine)
+                })
             } else {
                 Ok(StringChunked::full_null(ca.name().clone(), pat.len()))
             }
@@ -170,7 +166,7 @@ pub(super) fn extract_group(
         (len_ca, len_pat) if len_ca == len_pat => try_binary_mut_with_options(
             ca,
             pat,
-            |ca, pat| extract_group_binary(ca, pat, group_index),
+            |ca, pat| extract_group_binary(ca, pat, group_index, engine),
             ca.name().clone(),
         ),
         _ => {

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -7,7 +7,7 @@ use base64::engine::general_purpose;
 #[cfg(feature = "string_to_integer")]
 use num_traits::Num;
 use polars_core::prelude::arity::*;
-use polars_utils::regex_cache::{compile_regex, with_regex_cache};
+use polars_utils::regex_cache::{RegexEngine, compile_regex, with_regex_cache};
 
 use super::*;
 #[cfg(feature = "binary_encoding")]
@@ -142,6 +142,7 @@ pub trait StringNameSpaceImpl: AsString {
         pat: &StringChunked,
         literal: bool,
         strict: bool,
+        engine: RegexEngine,
     ) -> PolarsResult<BooleanChunked> {
         let ca = self.as_string();
         match (ca.len(), pat.len()) {
@@ -150,7 +151,7 @@ pub trait StringNameSpaceImpl: AsString {
                     if literal {
                         ca.contains_literal(pat)
                     } else {
-                        ca.contains(pat, strict)
+                        ca.contains(pat, strict, engine)
                     }
                 },
                 None => Ok(BooleanChunked::full_null(ca.name().clone(), ca.len())),
@@ -169,7 +170,7 @@ pub trait StringNameSpaceImpl: AsString {
                         broadcast_try_binary_elementwise(ca, pat, |opt_src, opt_pat| {
                             match (opt_src, opt_pat) {
                                 (Some(src), Some(pat)) => {
-                                    let reg = reg_cache.compile(pat)?;
+                                    let reg = reg_cache.compile_adapter(pat, engine)?;
                                     Ok(Some(reg.is_match(src)))
                                 },
                                 _ => Ok(None),
@@ -182,7 +183,7 @@ pub trait StringNameSpaceImpl: AsString {
                             ca,
                             pat,
                             infer_re_match(|src, pat| {
-                                let reg = reg_cache.compile(pat?).ok()?;
+                                let reg = reg_cache.compile_adapter(pat?, engine).ok()?;
                                 Some(reg.is_match(src?))
                             }),
                         ))
@@ -197,6 +198,7 @@ pub trait StringNameSpaceImpl: AsString {
         pat: &StringChunked,
         literal: bool,
         strict: bool,
+        engine: RegexEngine,
     ) -> PolarsResult<UInt32Chunked> {
         let ca = self.as_string();
         if pat.len() == 1 {
@@ -204,7 +206,7 @@ pub trait StringNameSpaceImpl: AsString {
                 if literal {
                     ca.find_literal(pat)
                 } else {
-                    ca.find(pat, strict)
+                    ca.find(pat, strict, engine)
                 }
             } else {
                 Ok(UInt32Chunked::full_null(ca.name().clone(), ca.len()))
@@ -225,7 +227,7 @@ pub trait StringNameSpaceImpl: AsString {
             with_regex_cache(|reg_cache| {
                 let matcher = |src: Option<&str>, pat: Option<&str>| -> PolarsResult<Option<u32>> {
                     if let (Some(src), Some(pat)) = (src, pat) {
-                        let re = reg_cache.compile(pat)?;
+                        let re = reg_cache.compile_adapter(pat, engine)?;
                         return Ok(re.find(src).map(|m| m.start() as u32));
                     }
                     Ok(None)
@@ -282,9 +284,14 @@ pub trait StringNameSpaceImpl: AsString {
     }
 
     /// Check if strings contain a regex pattern.
-    fn contains(&self, pat: &str, strict: bool) -> PolarsResult<BooleanChunked> {
+    fn contains(
+        &self,
+        pat: &str,
+        strict: bool,
+        engine: RegexEngine,
+    ) -> PolarsResult<BooleanChunked> {
         let ca = self.as_string();
-        let res_reg = polars_utils::regex_cache::compile_regex(pat);
+        let res_reg = compile_regex(pat, engine);
         let opt_reg = if strict { Some(res_reg?) } else { res_reg.ok() };
         let out: BooleanChunked = if let Some(reg) = opt_reg {
             unary_elementwise_values(ca, |s| reg.is_match(s))
@@ -299,18 +306,18 @@ pub trait StringNameSpaceImpl: AsString {
         // note: benchmarking shows that the regex engine is actually
         // faster at finding literal matches than str::contains.
         // ref: https://github.com/pola-rs/polars/pull/6811
-        self.contains(regex::escape(lit).as_str(), true)
+        self.contains(regex::escape(lit).as_str(), true, Default::default())
     }
 
     /// Return the index position of a literal substring in the target string.
     fn find_literal(&self, lit: &str) -> PolarsResult<UInt32Chunked> {
-        self.find(regex::escape(lit).as_str(), true)
+        self.find(regex::escape(lit).as_str(), true, Default::default())
     }
 
     /// Return the index position of a regular expression substring in the target string.
-    fn find(&self, pat: &str, strict: bool) -> PolarsResult<UInt32Chunked> {
+    fn find(&self, pat: &str, strict: bool, engine: RegexEngine) -> PolarsResult<UInt32Chunked> {
         let ca = self.as_string();
-        match polars_utils::regex_cache::compile_regex(pat) {
+        match compile_regex(pat, engine) {
             Ok(rx) => Ok(unary_elementwise(ca, |opt_s| {
                 opt_s.and_then(|s| rx.find(s)).map(|m| m.start() as u32)
             })),
@@ -322,8 +329,13 @@ pub trait StringNameSpaceImpl: AsString {
     }
 
     /// Replace the leftmost regex-matched (sub)string with another string
-    fn replace<'a>(&'a self, pat: &str, val: &str) -> PolarsResult<StringChunked> {
-        let reg = polars_utils::regex_cache::compile_regex(pat)?;
+    fn replace<'a>(
+        &'a self,
+        pat: &str,
+        val: &str,
+        engine: RegexEngine,
+    ) -> PolarsResult<StringChunked> {
+        let reg = compile_regex(pat, engine)?;
         let f = |s: &'a str| reg.replace(s, val);
         let ca = self.as_string();
         Ok(ca.apply_values(f))
@@ -371,9 +383,14 @@ pub trait StringNameSpaceImpl: AsString {
     }
 
     /// Replace all regex-matched (sub)strings with another string
-    fn replace_all(&self, pat: &str, val: &str) -> PolarsResult<StringChunked> {
+    fn replace_all(
+        &self,
+        pat: &str,
+        val: &str,
+        engine: RegexEngine,
+    ) -> PolarsResult<StringChunked> {
         let ca = self.as_string();
-        let reg = polars_utils::regex_cache::compile_regex(pat)?;
+        let reg = compile_regex(pat, engine)?;
         Ok(ca.apply_values(|s| reg.replace_all(s, val)))
     }
 
@@ -414,15 +431,20 @@ pub trait StringNameSpaceImpl: AsString {
     }
 
     /// Extract the nth capture group from pattern.
-    fn extract(&self, pat: &StringChunked, group_index: usize) -> PolarsResult<StringChunked> {
+    fn extract(
+        &self,
+        pat: &StringChunked,
+        group_index: usize,
+        engine: RegexEngine,
+    ) -> PolarsResult<StringChunked> {
         let ca = self.as_string();
-        super::extract::extract_group(ca, pat, group_index)
+        super::extract::extract_group(ca, pat, group_index, engine)
     }
 
     /// Extract each successive non-overlapping regex match in an individual string as an array.
-    fn extract_all(&self, pat: &str) -> PolarsResult<ListChunked> {
+    fn extract_all(&self, pat: &str, engine: RegexEngine) -> PolarsResult<ListChunked> {
         let ca = self.as_string();
-        let reg = polars_utils::regex_cache::compile_regex(pat)?;
+        let reg = compile_regex(pat, engine)?;
 
         let mut builder =
             ListStringChunkedBuilder::new(ca.name().clone(), ca.len(), ca.get_values_size());
@@ -506,7 +528,11 @@ pub trait StringNameSpaceImpl: AsString {
     }
 
     /// Extract each successive non-overlapping regex match in an individual string as an array.
-    fn extract_all_many(&self, pat: &StringChunked) -> PolarsResult<ListChunked> {
+    fn extract_all_many(
+        &self,
+        pat: &StringChunked,
+        engine: RegexEngine,
+    ) -> PolarsResult<ListChunked> {
         let ca = self.as_string();
         polars_ensure!(
             ca.len() == pat.len(),
@@ -519,9 +545,9 @@ pub trait StringNameSpaceImpl: AsString {
         with_regex_cache(|re_cache| {
             binary_elementwise_for_each(ca, pat, |opt_s, opt_pat| match (opt_s, opt_pat) {
                 (_, None) | (None, _) => builder.append_null(),
-                (Some(s), Some(pat)) => {
-                    let re = re_cache.compile(pat).unwrap();
-                    builder.append_values_iter(re.find_iter(s).map(|m| m.as_str()));
+                (Some(s), Some(pat)) => match re_cache.compile_adapter(pat, engine) {
+                    Ok(re) => builder.append_values_iter(re.find_iter(s).map(|m| m.as_str())),
+                    Err(_) => builder.append_null(),
                 },
             });
         });
@@ -530,22 +556,32 @@ pub trait StringNameSpaceImpl: AsString {
 
     #[cfg(feature = "extract_groups")]
     /// Extract all capture groups from pattern and return as a struct.
-    fn extract_groups(&self, pat: &str, dtype: &DataType) -> PolarsResult<Series> {
+    fn extract_groups(
+        &self,
+        pat: &str,
+        dtype: &DataType,
+        engine: RegexEngine,
+    ) -> PolarsResult<Series> {
         let ca = self.as_string();
-        super::extract::extract_groups(ca, pat, dtype)
+        super::extract::extract_groups(ca, pat, dtype, engine)
     }
 
     /// Count all successive non-overlapping regex matches.
-    fn count_matches(&self, pat: &str, literal: bool) -> PolarsResult<UInt32Chunked> {
+    fn count_matches(
+        &self,
+        pat: &str,
+        literal: bool,
+        engine: RegexEngine,
+    ) -> PolarsResult<UInt32Chunked> {
         let ca = self.as_string();
         if literal {
             Ok(unary_elementwise(ca, |opt_s| {
                 opt_s.map(|s| s.matches(pat).count() as u32)
             }))
         } else {
-            let re = compile_regex(pat)?;
+            let re = compile_regex(pat, engine)?;
             Ok(unary_elementwise(ca, |opt_s| {
-                opt_s.map(|s| re.find_iter(s).count() as u32)
+                opt_s.map(|s| re.count_matches(s) as u32)
             }))
         }
     }
@@ -555,6 +591,7 @@ pub trait StringNameSpaceImpl: AsString {
         &self,
         pat: &StringChunked,
         literal: bool,
+        engine: RegexEngine,
     ) -> PolarsResult<UInt32Chunked> {
         let ca = self.as_string();
         polars_ensure!(
@@ -574,8 +611,8 @@ pub trait StringNameSpaceImpl: AsString {
                       -> PolarsResult<Option<u32>> {
                     match (opt_s, opt_pat) {
                         (Some(s), Some(pat)) => {
-                            let reg = re_cache.compile(pat)?;
-                            Ok(Some(reg.find_iter(s).count() as u32))
+                            let reg = re_cache.compile_adapter(pat, engine)?;
+                            Ok(Some(reg.count_matches(s) as u32))
                         },
                         _ => Ok(None),
                     }

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -1,13 +1,13 @@
 use std::borrow::Cow;
 
-use arrow::legacy::utils::CustomIterTools;
 #[cfg(feature = "timezones")]
 use polars_core::chunked_array::temporal::validate_time_zone;
-use polars_core::utils::handle_casting_failures;
+use polars_core::prelude::*;
+use polars_core::utils::{CustomIterTools, handle_casting_failures};
 #[cfg(feature = "dtype-struct")]
 use polars_utils::format_pl_smallstr;
-#[cfg(feature = "regex")]
-use regex::{NoExpand, escape};
+use polars_utils::regex_cache::RegexEngine;
+use regex::escape;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -36,20 +36,31 @@ pub enum StringFunction {
     Contains {
         literal: bool,
         strict: bool,
+        engine: RegexEngine,
     },
-    CountMatches(bool),
+    CountMatches {
+        literal: bool,
+        engine: RegexEngine,
+    },
     EndsWith,
-    Extract(usize),
-    ExtractAll,
+    Extract {
+        group_index: usize,
+        engine: RegexEngine,
+    },
+    ExtractAll {
+        engine: RegexEngine,
+    },
     #[cfg(feature = "extract_groups")]
     ExtractGroups {
         dtype: DataType,
         pat: PlSmallStr,
+        engine: RegexEngine,
     },
     #[cfg(feature = "regex")]
     Find {
         literal: bool,
         strict: bool,
+        engine: RegexEngine,
     },
     #[cfg(feature = "string_to_integer")]
     ToInteger(bool),
@@ -69,6 +80,7 @@ pub enum StringFunction {
         // how many matches to replace
         n: i64,
         literal: bool,
+        engine: RegexEngine,
     },
     #[cfg(feature = "string_normalize")]
     Normalize {
@@ -150,10 +162,10 @@ impl StringFunction {
             ConcatVertical { .. } | ConcatHorizontal { .. } => mapper.with_dtype(DataType::String),
             #[cfg(feature = "regex")]
             Contains { .. } => mapper.with_dtype(DataType::Boolean),
-            CountMatches(_) => mapper.with_dtype(DataType::UInt32),
+            CountMatches { .. } => mapper.with_dtype(DataType::UInt32),
             EndsWith | StartsWith => mapper.with_dtype(DataType::Boolean),
-            Extract(_) => mapper.with_same_dtype(),
-            ExtractAll => mapper.with_dtype(DataType::List(Box::new(DataType::String))),
+            Extract { .. } => mapper.with_same_dtype(),
+            ExtractAll { .. } => mapper.with_dtype(DataType::List(Box::new(DataType::String))),
             #[cfg(feature = "extract_groups")]
             ExtractGroups { dtype, .. } => mapper.with_dtype(dtype.clone()),
             #[cfg(feature = "string_to_integer")]
@@ -227,11 +239,11 @@ impl StringFunction {
             S::Contains { .. } => {
                 FunctionOptions::elementwise().with_supertyping(Default::default())
             },
-            S::CountMatches(_) => FunctionOptions::elementwise(),
-            S::EndsWith | S::StartsWith | S::Extract(_) => {
+            S::CountMatches { .. } => FunctionOptions::elementwise(),
+            S::EndsWith | S::StartsWith | S::Extract { .. } => {
                 FunctionOptions::elementwise().with_supertyping(Default::default())
             },
-            S::ExtractAll => FunctionOptions::elementwise(),
+            S::ExtractAll { .. } => FunctionOptions::elementwise(),
             #[cfg(feature = "extract_groups")]
             S::ExtractGroups { .. } => FunctionOptions::elementwise(),
             #[cfg(feature = "string_to_integer")]
@@ -301,14 +313,14 @@ impl Display for StringFunction {
         let s = match self {
             #[cfg(feature = "regex")]
             Contains { .. } => "contains",
-            CountMatches(_) => "count_matches",
+            CountMatches { .. } => "count_matches",
             EndsWith => "ends_with",
-            Extract(_) => "extract",
+            Extract { .. } => "extract",
             #[cfg(feature = "concat_str")]
             ConcatHorizontal { .. } => "concat_horizontal",
             #[cfg(feature = "concat_str")]
             ConcatVertical { .. } => "concat_vertical",
-            ExtractAll => "extract_all",
+            ExtractAll { .. } => "extract_all",
             #[cfg(feature = "extract_groups")]
             ExtractGroups { .. } => "extract_groups",
             #[cfg(feature = "string_to_integer")]
@@ -395,22 +407,33 @@ impl From<StringFunction> for SpecialEq<Arc<dyn ColumnsUdf>> {
         use StringFunction::*;
         match func {
             #[cfg(feature = "regex")]
-            Contains { literal, strict } => map_as_slice!(strings::contains, literal, strict),
-            CountMatches(literal) => {
-                map_as_slice!(strings::count_matches, literal)
+            Contains {
+                literal,
+                strict,
+                engine,
+            } => map_as_slice!(strings::contains, literal, strict, engine),
+            CountMatches { literal, engine } => {
+                map_as_slice!(count_matches, literal, engine)
             },
             EndsWith => map_as_slice!(strings::ends_with),
             StartsWith => map_as_slice!(strings::starts_with),
-            Extract(group_index) => map_as_slice!(strings::extract, group_index),
-            ExtractAll => {
-                map_as_slice!(strings::extract_all)
+            Extract {
+                group_index,
+                engine,
+            } => map_as_slice!(strings::extract, group_index, engine),
+            ExtractAll { engine } => {
+                map_as_slice!(strings::extract_all, engine)
             },
             #[cfg(feature = "extract_groups")]
-            ExtractGroups { pat, dtype } => {
-                map!(strings::extract_groups, &pat, &dtype)
+            ExtractGroups { pat, dtype, engine } => {
+                map!(extract_groups, &pat, &dtype, engine)
             },
             #[cfg(feature = "regex")]
-            Find { literal, strict } => map_as_slice!(strings::find, literal, strict),
+            Find {
+                literal,
+                strict,
+                engine,
+            } => map_as_slice!(find, literal, strict, engine),
             LenBytes => map!(strings::len_bytes),
             LenChars => map!(strings::len_chars),
             #[cfg(feature = "string_pad")]
@@ -447,7 +470,7 @@ impl From<StringFunction> for SpecialEq<Arc<dyn ColumnsUdf>> {
                 ignore_nulls,
             } => map_as_slice!(strings::concat_hor, &delimiter, ignore_nulls),
             #[cfg(feature = "regex")]
-            Replace { n, literal } => map_as_slice!(strings::replace, literal, n),
+            Replace { n, literal, engine } => map_as_slice!(strings::replace, literal, n, engine),
             #[cfg(feature = "string_normalize")]
             Normalize { form } => map!(strings::normalize, form.clone()),
             #[cfg(feature = "string_reverse")]
@@ -595,20 +618,30 @@ pub(super) fn len_bytes(s: &Column) -> PolarsResult<Column> {
 }
 
 #[cfg(feature = "regex")]
-pub(super) fn contains(s: &[Column], literal: bool, strict: bool) -> PolarsResult<Column> {
+pub(super) fn contains(
+    s: &[Column],
+    literal: bool,
+    strict: bool,
+    engine: RegexEngine,
+) -> PolarsResult<Column> {
     _check_same_length(s, "contains")?;
     let ca = s[0].str()?;
     let pat = s[1].str()?;
-    ca.contains_chunked(pat, literal, strict)
+    ca.contains_chunked(pat, literal, strict, engine)
         .map(|ok| ok.into_column())
 }
 
 #[cfg(feature = "regex")]
-pub(super) fn find(s: &[Column], literal: bool, strict: bool) -> PolarsResult<Column> {
+pub(super) fn find(
+    s: &[Column],
+    literal: bool,
+    strict: bool,
+    engine: RegexEngine,
+) -> PolarsResult<Column> {
     _check_same_length(s, "find")?;
     let ca = s[0].str()?;
     let pat = s[1].str()?;
-    ca.find_chunked(pat, literal, strict)
+    ca.find_chunked(pat, literal, strict, engine)
         .map(|ok| ok.into_column())
 }
 
@@ -628,17 +661,27 @@ pub(super) fn starts_with(s: &[Column]) -> PolarsResult<Column> {
 }
 
 /// Extract a regex pattern from the a string value.
-pub(super) fn extract(s: &[Column], group_index: usize) -> PolarsResult<Column> {
+pub(super) fn extract(
+    s: &[Column],
+    group_index: usize,
+    engine: RegexEngine,
+) -> PolarsResult<Column> {
     let ca = s[0].str()?;
     let pat = s[1].str()?;
-    ca.extract(pat, group_index).map(|ca| ca.into_column())
+    ca.extract(pat, group_index, engine)
+        .map(|ca| ca.into_column())
 }
 
 #[cfg(feature = "extract_groups")]
 /// Extract all capture groups from a regex pattern as a struct
-pub(super) fn extract_groups(s: &Column, pat: &str, dtype: &DataType) -> PolarsResult<Column> {
+pub(super) fn extract_groups(
+    s: &Column,
+    pat: &str,
+    dtype: &DataType,
+    engine: RegexEngine,
+) -> PolarsResult<Column> {
     let ca = s.str()?;
-    ca.extract_groups(pat, dtype).map(Column::from)
+    ca.extract_groups(pat, dtype, engine).map(Column::from)
 }
 
 #[cfg(feature = "string_pad")]
@@ -697,7 +740,7 @@ pub(super) fn strip_suffix(s: &[Column]) -> PolarsResult<Column> {
     Ok(ca.strip_suffix(suffix).into_column())
 }
 
-pub(super) fn extract_all(args: &[Column]) -> PolarsResult<Column> {
+pub(super) fn extract_all(args: &[Column], engine: RegexEngine) -> PolarsResult<Column> {
     let s = &args[0];
     let pat = &args[1];
 
@@ -706,7 +749,7 @@ pub(super) fn extract_all(args: &[Column]) -> PolarsResult<Column> {
 
     if pat.len() == 1 {
         if let Some(pat) = pat.get(0) {
-            ca.extract_all(pat).map(|ca| ca.into_column())
+            ca.extract_all(pat, engine).map(|ca| ca.into_column())
         } else {
             Ok(Column::full_null(
                 ca.name().clone(),
@@ -715,11 +758,15 @@ pub(super) fn extract_all(args: &[Column]) -> PolarsResult<Column> {
             ))
         }
     } else {
-        ca.extract_all_many(pat).map(|ca| ca.into_column())
+        ca.extract_all_many(pat, engine).map(|ca| ca.into_column())
     }
 }
 
-pub(super) fn count_matches(args: &[Column], literal: bool) -> PolarsResult<Column> {
+pub(super) fn count_matches(
+    args: &[Column],
+    literal: bool,
+    engine: RegexEngine,
+) -> PolarsResult<Column> {
     let s = &args[0];
     let pat = &args[1];
 
@@ -727,7 +774,8 @@ pub(super) fn count_matches(args: &[Column], literal: bool) -> PolarsResult<Colu
     let pat = pat.str()?;
     if pat.len() == 1 {
         if let Some(pat) = pat.get(0) {
-            ca.count_matches(pat, literal).map(|ca| ca.into_column())
+            ca.count_matches(pat, literal, engine)
+                .map(|ca| ca.into_column())
         } else {
             Ok(Column::full_null(
                 ca.name().clone(),
@@ -736,7 +784,7 @@ pub(super) fn count_matches(args: &[Column], literal: bool) -> PolarsResult<Colu
             ))
         }
     } else {
-        ca.count_matches_many(pat, literal)
+        ca.count_matches_many(pat, literal, engine)
             .map(|ca| ca.into_column())
     }
 }
@@ -949,6 +997,7 @@ fn replace_n<'a>(
     val: &'a StringChunked,
     literal: bool,
     n: usize,
+    engine: RegexEngine,
 ) -> PolarsResult<StringChunked> {
     match (pat.len(), val.len()) {
         (1, 1) => {
@@ -964,7 +1013,7 @@ fn replace_n<'a>(
                     if n > 1 {
                         polars_bail!(ComputeError: "regex replacement with 'n > 1' not yet supported")
                     }
-                    ca.replace(pat, val)
+                    ca.replace(pat, val, engine)
                 },
             }
         },
@@ -986,19 +1035,13 @@ fn replace_n<'a>(
                 pat = escape(&pat)
             }
 
-            let reg = polars_utils::regex_cache::compile_regex(&pat)?;
+            let reg = polars_utils::regex_cache::compile_regex(&pat, engine)?;
 
             let f = |s: &'a str, val: &'a str| {
-                if lit && (s.len() <= 32) {
+                if literal_pat {
                     Cow::Owned(s.replacen(&pat, val, 1))
                 } else {
-                    // According to the docs for replace
-                    // when literal = True then capture groups are ignored.
-                    if literal {
-                        reg.replace(s, NoExpand(val))
-                    } else {
-                        reg.replace(s, val)
-                    }
+                    reg.replace(s, val)
                 }
             };
             Ok(iter_and_replace(ca, val, f))
@@ -1015,6 +1058,7 @@ fn replace_all<'a>(
     pat: &'a StringChunked,
     val: &'a StringChunked,
     literal: bool,
+    engine: RegexEngine,
 ) -> PolarsResult<StringChunked> {
     match (pat.len(), val.len()) {
         (1, 1) => {
@@ -1026,7 +1070,7 @@ fn replace_all<'a>(
 
             match literal {
                 true => ca.replace_literal_all(pat, val),
-                false => ca.replace_all(pat, val),
+                false => ca.replace_all(pat, val, engine),
             }
         },
         (1, len_val) => {
@@ -1044,18 +1088,16 @@ fn replace_all<'a>(
                 pat = escape(&pat)
             }
 
-            let reg = polars_utils::regex_cache::compile_regex(&pat)?;
+            let reg = polars_utils::regex_cache::compile_regex(&pat, engine)?;
 
             let f = |s: &'a str, val: &'a str| {
-                // According to the docs for replace_all
-                // when literal = True then capture groups are ignored.
-                if literal {
-                    reg.replace_all(s, NoExpand(val))
+                if literal_pat {
+                    // When literal mode is enabled, use literal string replacement
+                    Cow::Owned(s.replace(&pat, val))
                 } else {
                     reg.replace_all(s, val)
                 }
             };
-
             Ok(iter_and_replace(ca, val, f))
         },
         _ => polars_bail!(
@@ -1065,7 +1107,12 @@ fn replace_all<'a>(
 }
 
 #[cfg(feature = "regex")]
-pub(super) fn replace(s: &[Column], literal: bool, n: i64) -> PolarsResult<Column> {
+pub(super) fn replace(
+    s: &[Column],
+    literal: bool,
+    n: i64,
+    engine: RegexEngine,
+) -> PolarsResult<Column> {
     let column = &s[0];
     let pat = &s[1];
     let val = &s[2];
@@ -1076,9 +1123,9 @@ pub(super) fn replace(s: &[Column], literal: bool, n: i64) -> PolarsResult<Colum
     let val = val.str()?;
 
     if all {
-        replace_all(column, pat, val, literal)
+        replace_all(column, pat, val, literal, engine)
     } else {
-        replace_n(column, pat, val, literal, n as usize)
+        replace_n(column, pat, val, literal, n as usize, engine)
     }
     .map(|ca| ca.into_column())
 }

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -1,15 +1,17 @@
+use polars_utils::regex_cache::{RegexEngine, compile_regex};
+
 use super::*;
 /// Specialized expressions for [`Series`] of [`DataType::String`].
 pub struct StringNameSpace(pub(crate) Expr);
 
 impl StringNameSpace {
     /// Check if a string value contains a literal substring.
-    #[cfg(feature = "regex")]
     pub fn contains_literal(self, pat: Expr) -> Expr {
         self.0.map_binary(
             StringFunction::Contains {
                 literal: true,
                 strict: false,
+                engine: RegexEngine::default(),
             },
             pat,
         )
@@ -17,12 +19,14 @@ impl StringNameSpace {
 
     /// Check if this column of strings contains a Regex. If `strict` is `true`, then it is an error if any `pat` is
     /// an invalid regex, whereas if `strict` is `false`, an invalid regex will simply evaluate to `false`.
+    /// If `engine` is not the default, it enables different regex engines with various feature sets.
     #[cfg(feature = "regex")]
-    pub fn contains(self, pat: Expr, strict: bool) -> Expr {
+    pub fn contains(self, pat: Expr, strict: bool, engine: RegexEngine) -> Expr {
         self.0.map_binary(
             StringFunction::Contains {
                 literal: false,
                 strict,
+                engine,
             },
             pat,
         )
@@ -145,18 +149,26 @@ impl StringNameSpace {
     }
 
     /// Extract a regex pattern from the a string value. If `group_index` is out of bounds, null is returned.
-    pub fn extract(self, pat: Expr, group_index: usize) -> Expr {
-        self.0.map_binary(StringFunction::Extract(group_index), pat)
+    /// If `engine` is not the default, it enables different regex engines with various feature sets.
+    pub fn extract(self, pat: Expr, group_index: usize, engine: RegexEngine) -> Expr {
+        self.0.map_binary(
+            StringFunction::Extract {
+                group_index,
+                engine,
+            },
+            pat,
+        )
     }
 
     #[cfg(feature = "extract_groups")]
     // Extract all captures groups from a regex pattern as a struct
-    pub fn extract_groups(self, pat: &str) -> PolarsResult<Expr> {
+    /// If `engine` is not the default, it enables different regex engines with various feature sets.
+    pub fn extract_groups(self, pat: &str, engine: RegexEngine) -> PolarsResult<Expr> {
         // regex will be compiled twice, because it doesn't support serde
         // and we need to compile it here to determine the output datatype
 
         use polars_utils::format_pl_smallstr;
-        let reg = polars_utils::regex_cache::compile_regex(pat)?;
+        let reg = compile_regex(pat, engine)?;
         let names = reg
             .capture_names()
             .enumerate()
@@ -178,6 +190,7 @@ impl StringNameSpace {
         Ok(self.0.map_unary(StringFunction::ExtractGroups {
             dtype,
             pat: pat.into(),
+            engine,
         }))
     }
 
@@ -221,32 +234,40 @@ impl StringNameSpace {
             StringFunction::Find {
                 literal: true,
                 strict: false,
+                engine: RegexEngine::default(),
             },
             pat,
         )
     }
 
     /// Find the index of a substring defined by a regular expressions within another string value.
+    /// If `strict` is `true`, then it is an error if the underlying pattern is not a valid regex,
+    /// whereas if `strict` is `false`, an invalid regex will simply evaluate to `null`.
+    /// If `engine` is not the default, it enables different regex engines with various feature sets.
     #[cfg(feature = "regex")]
-    pub fn find(self, pat: Expr, strict: bool) -> Expr {
+    pub fn find(self, pat: Expr, strict: bool, engine: RegexEngine) -> Expr {
         self.0.map_binary(
             StringFunction::Find {
                 literal: false,
                 strict,
+                engine,
             },
             pat,
         )
     }
 
     /// Extract each successive non-overlapping match in an individual string as an array
-    pub fn extract_all(self, pat: Expr) -> Expr {
-        self.0.map_binary(StringFunction::ExtractAll, pat)
+    /// If `engine` is not the default, it enables different regex engines with various feature sets.
+    pub fn extract_all(self, pat: Expr, engine: RegexEngine) -> Expr {
+        self.0
+            .map_binary(StringFunction::ExtractAll { engine }, pat)
     }
 
     /// Count all successive non-overlapping regex matches.
-    pub fn count_matches(self, pat: Expr, literal: bool) -> Expr {
+    /// If `engine` is not the default, it enables different regex engines with various feature sets.
+    pub fn count_matches(self, pat: Expr, literal: bool, engine: RegexEngine) -> Expr {
         self.0
-            .map_binary(StringFunction::CountMatches(literal), pat)
+            .map_binary(StringFunction::CountMatches { literal, engine }, pat)
     }
 
     /// Convert a String column into a Date/Datetime/Time column.
@@ -362,23 +383,47 @@ impl StringNameSpace {
 
     #[cfg(feature = "regex")]
     /// Replace values that match a regex `pat` with a `value`.
-    pub fn replace(self, pat: Expr, value: Expr, literal: bool) -> Expr {
-        self.0
-            .map_ternary(StringFunction::Replace { n: 1, literal }, pat, value)
+    /// If `engine` is not the default, it enables different regex engines with various feature sets.
+    pub fn replace(self, pat: Expr, value: Expr, literal: bool, engine: RegexEngine) -> Expr {
+        self.0.map_ternary(
+            StringFunction::Replace {
+                n: 1,
+                literal,
+                engine,
+            },
+            pat,
+            value,
+        )
     }
 
     #[cfg(feature = "regex")]
     /// Replace values that match a regex `pat` with a `value`.
-    pub fn replace_n(self, pat: Expr, value: Expr, literal: bool, n: i64) -> Expr {
+    /// If `engine` is not the default, it enables different regex engines with various feature sets.
+    pub fn replace_n(
+        self,
+        pat: Expr,
+        value: Expr,
+        literal: bool,
+        n: i64,
+        engine: RegexEngine,
+    ) -> Expr {
         self.0
-            .map_ternary(StringFunction::Replace { n, literal }, pat, value)
+            .map_ternary(StringFunction::Replace { n, literal, engine }, pat, value)
     }
 
     #[cfg(feature = "regex")]
     /// Replace all values that match a regex `pat` with a `value`.
-    pub fn replace_all(self, pat: Expr, value: Expr, literal: bool) -> Expr {
-        self.0
-            .map_ternary(StringFunction::Replace { n: -1, literal }, pat, value)
+    /// If `engine` is not the default, it enables different regex engines with various feature sets.
+    pub fn replace_all(self, pat: Expr, value: Expr, literal: bool, engine: RegexEngine) -> Expr {
+        self.0.map_ternary(
+            StringFunction::Replace {
+                n: -1,
+                literal,
+                engine,
+            },
+            pat,
+            value,
+        )
     }
 
     #[cfg(feature = "string_normalize")]

--- a/crates/polars-plan/src/plans/conversion/expr_expansion.rs
+++ b/crates/polars-plan/src/plans/conversion/expr_expansion.rs
@@ -109,7 +109,7 @@ fn expand_regex(
     pattern: &str,
     exclude: &PlHashSet<PlSmallStr>,
 ) -> PolarsResult<()> {
-    let re = polars_utils::regex_cache::compile_regex(pattern)
+    let re = polars_utils::regex_cache::compile_regex(pattern, Default::default())
         .map_err(|e| polars_err!(ComputeError: "invalid regex {}", e))?;
     for name in schema.iter_names() {
         if re.is_match(name) && !exclude.contains(name.as_str()) {
@@ -395,7 +395,7 @@ Hint: set 'upper_bound' for 'list.to_struct'.",
         else {
             #[cfg(feature = "regex")]
             {
-                let re = polars_utils::regex_cache::compile_regex(first_name)
+                let re = polars_utils::regex_cache::compile_regex(first_name, Default::default())
                     .map_err(|e| polars_err!(ComputeError: "invalid regex {}", e))?;
 
                 fields

--- a/crates/polars-python/src/conversion/mod.rs
+++ b/crates/polars-python/src/conversion/mod.rs
@@ -25,6 +25,7 @@ use polars_parquet::write::StatisticsOptions;
 use polars_plan::dsl::ScanSources;
 use polars_utils::mmap::MemSlice;
 use polars_utils::pl_str::PlSmallStr;
+use polars_utils::regex_adapter::RegexEngine;
 use polars_utils::total_ord::{TotalEq, TotalHash};
 use pyo3::basic::CompareOp;
 use pyo3::exceptions::{PyTypeError, PyValueError};
@@ -484,6 +485,20 @@ impl<'py> IntoPyObject<'py> for Wrap<TimeUnit> {
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         self.0.to_ascii().into_pyobject(py)
+    }
+}
+
+impl<'py> FromPyObject<'py> for Wrap<RegexEngine> {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        let s = ob.extract::<PyBackedStr>()?;
+        let s_ref: &str = s.as_ref();
+        match s_ref.parse::<RegexEngine>() {
+            Ok(engine) => Ok(Wrap(engine)),
+            Err(_) => Err(PyValueError::new_err(format!(
+                "`engine` must be one of {{'regex'}}, got {}",
+                s_ref
+            ))),
+        }
     }
 }
 

--- a/crates/polars-python/src/expr/string.rs
+++ b/crates/polars-python/src/expr/string.rs
@@ -143,7 +143,7 @@ impl PyExpr {
         self.inner
             .clone()
             .str()
-            .replace_n(pat.inner, val.inner, literal, n)
+            .replace_n(pat.inner, val.inner, literal, n, Default::default())
             .into()
     }
 
@@ -152,7 +152,7 @@ impl PyExpr {
         self.inner
             .clone()
             .str()
-            .replace_all(pat.inner, val.inner, literal)
+            .replace_all(pat.inner, val.inner, literal, Default::default())
             .into()
     }
 
@@ -181,7 +181,12 @@ impl PyExpr {
     fn str_contains(&self, pat: Self, literal: Option<bool>, strict: bool) -> Self {
         match literal {
             Some(true) => self.inner.clone().str().contains_literal(pat.inner).into(),
-            _ => self.inner.clone().str().contains(pat.inner, strict).into(),
+            _ => self
+                .inner
+                .clone()
+                .str()
+                .contains(pat.inner, strict, Default::default())
+                .into(),
         }
     }
 
@@ -190,7 +195,12 @@ impl PyExpr {
     fn str_find(&self, pat: Self, literal: Option<bool>, strict: bool) -> Self {
         match literal {
             Some(true) => self.inner.clone().str().find_literal(pat.inner).into(),
-            _ => self.inner.clone().str().find(pat.inner, strict).into(),
+            _ => self
+                .inner
+                .clone()
+                .str()
+                .find(pat.inner, strict, Default::default())
+                .into(),
         }
     }
 
@@ -253,12 +263,16 @@ impl PyExpr {
         self.inner
             .clone()
             .str()
-            .extract(pat.inner, group_index)
+            .extract(pat.inner, group_index, Default::default())
             .into()
     }
 
     fn str_extract_all(&self, pat: Self) -> Self {
-        self.inner.clone().str().extract_all(pat.inner).into()
+        self.inner
+            .clone()
+            .str()
+            .extract_all(pat.inner, Default::default())
+            .into()
     }
 
     #[cfg(feature = "extract_groups")]
@@ -267,7 +281,7 @@ impl PyExpr {
             .inner
             .clone()
             .str()
-            .extract_groups(pat)
+            .extract_groups(pat, Default::default())
             .map_err(PyPolarsErr::from)?
             .into())
     }
@@ -276,7 +290,7 @@ impl PyExpr {
         self.inner
             .clone()
             .str()
-            .count_matches(pat.inner, literal)
+            .count_matches(pat.inner, literal, Default::default())
             .into()
     }
 

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -765,28 +765,37 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                     )
                         .into_py_any(py),
                     #[cfg(feature = "regex")]
-                    StringFunction::Contains { literal, strict } => {
-                        (PyStringFunction::Contains, literal, strict).into_py_any(py)
-                    },
-                    StringFunction::CountMatches(literal) => {
-                        (PyStringFunction::CountMatches, literal).into_py_any(py)
+                    StringFunction::Contains {
+                        literal,
+                        strict,
+                        engine,
+                    } => (PyStringFunction::Contains, literal, strict, engine.as_ref())
+                        .into_py_any(py),
+                    StringFunction::CountMatches { literal, engine } => {
+                        (PyStringFunction::CountMatches, literal, engine.as_ref()).into_py_any(py)
                     },
                     StringFunction::EndsWith => (PyStringFunction::EndsWith,).into_py_any(py),
-                    StringFunction::Extract(group_index) => {
-                        (PyStringFunction::Extract, group_index).into_py_any(py)
+                    StringFunction::Extract {
+                        group_index,
+                        engine,
+                    } => (PyStringFunction::Extract, group_index, engine.as_ref()).into_py_any(py),
+                    StringFunction::ExtractAll { engine } => {
+                        (PyStringFunction::ExtractAll, engine.as_ref()).into_py_any(py)
                     },
-                    StringFunction::ExtractAll => (PyStringFunction::ExtractAll,).into_py_any(py),
                     #[cfg(feature = "extract_groups")]
-                    StringFunction::ExtractGroups { dtype, pat } => (
+                    StringFunction::ExtractGroups { dtype, pat, engine } => (
                         PyStringFunction::ExtractGroups,
                         &Wrap(dtype.clone()),
                         pat.as_str(),
+                        engine.as_ref(),
                     )
                         .into_py_any(py),
                     #[cfg(feature = "regex")]
-                    StringFunction::Find { literal, strict } => {
-                        (PyStringFunction::Find, literal, strict).into_py_any(py)
-                    },
+                    StringFunction::Find {
+                        literal,
+                        strict,
+                        engine,
+                    } => (PyStringFunction::Find, literal, strict, engine.as_ref()).into_py_any(py),
                     StringFunction::ToInteger(strict) => {
                         (PyStringFunction::ToInteger, strict).into_py_any(py)
                     },
@@ -803,8 +812,8 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                         (PyStringFunction::JsonPathMatch,).into_py_any(py)
                     },
                     #[cfg(feature = "regex")]
-                    StringFunction::Replace { n, literal } => {
-                        (PyStringFunction::Replace, n, literal).into_py_any(py)
+                    StringFunction::Replace { n, literal, engine } => {
+                        (PyStringFunction::Replace, n, literal, engine.as_ref()).into_py_any(py)
                     },
                     StringFunction::Normalize { form } => (
                         PyStringFunction::Normalize,

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -32,10 +32,10 @@ pub struct TableInfo {
 }
 
 struct SelectModifiers {
-    exclude: PlHashSet<String>,                // SELECT * EXCLUDE
-    ilike: Option<regex::Regex>,               // SELECT * ILIKE
+    exclude: PlHashSet<String>, // SELECT * EXCLUDE
+    ilike: Option<polars_utils::regex_adapter::RegexAdapter>, // SELECT * ILIKE
     rename: PlHashMap<PlSmallStr, PlSmallStr>, // SELECT * RENAME
-    replace: Vec<Expr>,                        // SELECT * REPLACE
+    replace: Vec<Expr>,         // SELECT * REPLACE
 }
 impl SelectModifiers {
     fn matches_ilike(&self, s: &str) -> bool {
@@ -1476,8 +1476,11 @@ impl SQLContext {
                 .replace('_', ".");
 
             modifiers.ilike = Some(
-                polars_utils::regex_cache::compile_regex(format!("^(?is){}$", rx).as_str())
-                    .unwrap(),
+                polars_utils::regex_cache::compile_regex(
+                    format!("^(?is){}$", rx).as_str(),
+                    Default::default(),
+                )
+                .unwrap(),
             );
         }
 
@@ -1575,7 +1578,7 @@ fn expand_exprs(expr: Expr, schema: &SchemaRef) -> Vec<Expr> {
             .map(|name| col(name.clone()))
             .collect::<Vec<_>>(),
         Expr::Column(nm) if is_regex_colname(nm.as_str()) => {
-            let re = polars_utils::regex_cache::compile_regex(&nm).unwrap();
+            let re = polars_utils::regex_cache::compile_regex(&nm, Default::default()).unwrap();
             schema
                 .iter_names()
                 .filter(|name| re.is_match(name))

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1212,13 +1212,14 @@ impl SQLFunctionVisitor<'_> {
             StrPos => {
                 // note: SQL is 1-indexed; returns zero if no match found
                 self.visit_binary(|expr, substring| {
-                    (expr.str().find(substring, true) + typed_lit(1u32)).fill_null(typed_lit(0u32))
+                    (expr.str().find(substring, true, Default::default()) + typed_lit(1u32))
+                        .fill_null(typed_lit(0u32))
                 })
             },
             RegexpLike => {
                 let args = extract_args(function)?;
                 match args.len() {
-                    2 => self.visit_binary(|e, s| e.str().contains(s, true)),
+                    2 => self.visit_binary(|e, s| e.str().contains(s, true, Default::default())),
                     3 => self.try_visit_ternary(|e, pat, flags| {
                         Ok(e.str().contains(
                             match (pat, flags) {
@@ -1234,7 +1235,8 @@ impl SQLFunctionVisitor<'_> {
                                     polars_bail!(SQLSyntax: "invalid arguments for REGEXP_LIKE ({}, {})", args[1], args[2]);
                                 },
                             },
-                            true))
+                            true,
+                            Default::default()))
                     }),
                     _ => polars_bail!(SQLSyntax: "REGEXP_LIKE expects 2-3 arguments (found {})",args.len()),
                 }
@@ -1242,8 +1244,9 @@ impl SQLFunctionVisitor<'_> {
             Replace => {
                 let args = extract_args(function)?;
                 match args.len() {
-                    3 => self
-                        .try_visit_ternary(|e, old, new| Ok(e.str().replace_all(old, new, true))),
+                    3 => self.try_visit_ternary(|e, old, new| {
+                        Ok(e.str().replace_all(old, new, true, Default::default()))
+                    }),
                     _ => {
                         polars_bail!(SQLSyntax: "REPLACE expects 3 arguments (found {})", args.len())
                     },
@@ -1512,7 +1515,9 @@ impl SQLFunctionVisitor<'_> {
                             _ => format!("^.*{}.*$", pat),
                         };
                         if let Some(active_schema) = &active_schema {
-                            let rx = polars_utils::regex_cache::compile_regex(&pat).unwrap();
+                            let rx =
+                                polars_utils::regex_cache::compile_regex(&pat, Default::default())
+                                    .unwrap();
                             let col_names = active_schema
                                 .iter_names()
                                 .filter(|name| rx.is_match(name))

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -171,11 +171,11 @@ impl SQLExprVisitor<'_> {
             SQLExpr::Nested(expr) => self.visit_expr(expr),
             SQLExpr::Position { expr, r#in } => Ok(
                 // note: SQL is 1-indexed
-                (self
-                    .visit_expr(r#in)?
-                    .str()
-                    .find(self.visit_expr(expr)?, true)
-                    + typed_lit(1u32))
+                (self.visit_expr(r#in)?.str().find(
+                    self.visit_expr(expr)?,
+                    true,
+                    Default::default(),
+                ) + typed_lit(1u32))
                 .fill_null(typed_lit(0u32)),
             ),
             SQLExpr::RLike {
@@ -185,10 +185,11 @@ impl SQLExprVisitor<'_> {
                 pattern,
                 regexp: _,
             } => {
-                let matches = self
-                    .visit_expr(expr)?
-                    .str()
-                    .contains(self.visit_expr(pattern)?, true);
+                let matches = self.visit_expr(expr)?.str().contains(
+                    self.visit_expr(pattern)?,
+                    true,
+                    Default::default(),
+                );
                 Ok(if *negated { matches.not() } else { matches })
             },
             SQLExpr::Subscript { expr, subscript } => self.visit_subscript(expr, subscript),
@@ -339,7 +340,7 @@ impl SQLExprVisitor<'_> {
             );
 
             let expr = self.visit_expr(expr)?;
-            let matches = expr.str().contains(lit(rx), true);
+            let matches = expr.str().contains(lit(rx), true, Default::default());
             Ok(if negated { matches.not() } else { matches })
         }
     }
@@ -532,24 +533,24 @@ impl SQLExprVisitor<'_> {
             // Regular expression operators
             // ----
             SQLBinaryOperator::PGRegexMatch => match rhs {  // "x ~ y"
-                Expr::Literal(ref lv) if lv.extract_str().is_some() => lhs.str().contains(rhs, true),
+                Expr::Literal(ref lv) if lv.extract_str().is_some() => lhs.str().contains(rhs, true, Default::default()),
                 _ => polars_bail!(SQLSyntax: "invalid pattern for '~' operator: {:?}", rhs),
             },
             SQLBinaryOperator::PGRegexNotMatch => match rhs {  // "x !~ y"
-                Expr::Literal(ref lv) if lv.extract_str().is_some() => lhs.str().contains(rhs, true).not(),
+                Expr::Literal(ref lv) if lv.extract_str().is_some() => lhs.str().contains(rhs, true, Default::default()).not(),
                 _ => polars_bail!(SQLSyntax: "invalid pattern for '!~' operator: {:?}", rhs),
             },
             SQLBinaryOperator::PGRegexIMatch => match rhs {  // "x ~* y"
                 Expr::Literal(ref lv) if lv.extract_str().is_some() => {
                     let pat = lv.extract_str().unwrap();
-                    lhs.str().contains(lit(format!("(?i){}", pat)), true)
+                    lhs.str().contains(lit(format!("(?i){}", pat)), true, Default::default())
                 },
                 _ => polars_bail!(SQLSyntax: "invalid pattern for '~*' operator: {:?}", rhs),
             },
             SQLBinaryOperator::PGRegexNotIMatch => match rhs {  // "x !~* y"
                 Expr::Literal(ref lv) if lv.extract_str().is_some() => {
                     let pat = lv.extract_str().unwrap();
-                    lhs.str().contains(lit(format!("(?i){}", pat)), true).not()
+                    lhs.str().contains(lit(format!("(?i){}", pat)), true, Default::default()).not()
                 },
                 _ => {
                     polars_bail!(SQLSyntax: "invalid pattern for '!~*' operator: {:?}", rhs)

--- a/crates/polars-utils/Cargo.toml
+++ b/crates/polars-utils/Cargo.toml
@@ -31,6 +31,8 @@ serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 slotmap = { workspace = true }
 stacker = { workspace = true }
+strum = { workspace = true }
+strum_macros = { workspace = true }
 sysinfo = { version = "0.33", default-features = false, features = ["system"], optional = true }
 
 [dev-dependencies]

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -28,6 +28,7 @@ pub mod mem;
 pub mod min_max;
 pub mod pl_str;
 pub mod priority;
+pub mod regex_adapter;
 pub mod regex_cache;
 pub mod select;
 pub mod slice;

--- a/crates/polars-utils/src/regex_adapter.rs
+++ b/crates/polars-utils/src/regex_adapter.rs
@@ -1,0 +1,374 @@
+use std::borrow::Cow;
+
+use polars_error::{PolarsError, PolarsResult};
+pub use regex::Regex;
+use regex::{CaptureLocations as RegexCaptureLocations, NoExpand as RegexNoExpand, RegexBuilder};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+use strum_macros::{AsRefStr, EnumString};
+
+#[derive(AsRefStr, Clone, Copy, Debug, Default, EnumString, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[strum(serialize_all = "snake_case")]
+pub enum RegexEngine {
+    // `regex` crate
+    #[default]
+    Regex,
+}
+
+pub trait RegexTrait: Sized + Clone {
+    fn new(pattern: &str) -> PolarsResult<Self>;
+
+    fn is_match(&self, text: &str) -> bool;
+
+    fn find<'t>(&self, text: &'t str) -> Option<Match<'t>>;
+
+    fn find_iter<'t>(&'t self, text: &'t str) -> Box<dyn Iterator<Item = Match<'t>> + 't>;
+
+    fn replace<'t>(&self, text: &'t str, replacement: &str) -> Cow<'t, str>;
+
+    fn replace_all<'t>(&self, text: &'t str, replacement: &str) -> Cow<'t, str>;
+
+    fn replace_all_literal<'t>(&self, text: &'t str, replacement: &str) -> Cow<'t, str> {
+        replace_all_literal_from_spans(
+            text,
+            replacement,
+            self.find_iter(text).map(|m| (m.start(), m.end())),
+        )
+    }
+
+    fn captures<'t>(&self, text: &'t str) -> Option<CaptureGroups<'t>>;
+
+    fn captures_iter<'t>(
+        &'t self,
+        text: &'t str,
+    ) -> Box<dyn Iterator<Item = CaptureGroups<'t>> + 't>;
+
+    /// Get an iterator over the capture group names
+    fn capture_names(&self) -> CaptureNamesIterator<'_>;
+
+    /// Returns the number of capture groups in the pattern.
+    fn captures_len(&self) -> usize;
+
+    fn count_matches(&self, text: &str) -> usize {
+        self.find_iter(text).count()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Match<'t> {
+    pub text: &'t str,
+    pub start: usize,
+    pub end: usize,
+}
+
+impl<'t> Match<'t> {
+    pub fn as_str(&self) -> &'t str {
+        self.text
+    }
+
+    pub fn start(&self) -> usize {
+        self.start
+    }
+
+    pub fn end(&self) -> usize {
+        self.end
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CaptureGroups<'t> {
+    groups: Vec<Option<&'t str>>,
+}
+
+impl<'t> CaptureGroups<'t> {
+    /// Get the number of capture groups (including group 0)
+    pub fn len(&self) -> usize {
+        self.groups.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        !self.groups.first().is_some_and(|m| m.is_some())
+    }
+
+    /// Get a capture group by index
+    pub fn get(&self, index: usize) -> Option<&'t str> {
+        self.groups.get(index).copied().flatten()
+    }
+
+    /// Get the main match (group 0)
+    pub fn get_match(&self) -> Option<&'t str> {
+        self.get(0)
+    }
+
+    pub fn groups(&self) -> &[Option<&'t str>] {
+        &self.groups
+    }
+}
+
+fn build_capture_groups<'t, F>(len: usize, get_group: F) -> CaptureGroups<'t>
+where
+    F: FnMut(usize) -> Option<&'t str>,
+{
+    let groups = (0..len).map(get_group).collect();
+    CaptureGroups { groups }
+}
+
+pub enum CaptureNamesIterator<'a> {
+    Regex(regex::CaptureNames<'a>),
+}
+
+impl<'a> Iterator for CaptureNamesIterator<'a> {
+    type Item = Option<&'a str>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            CaptureNamesIterator::Regex(iter) => iter.next(),
+        }
+    }
+}
+
+impl RegexTrait for Regex {
+    #[allow(clippy::disallowed_methods)]
+    fn new(pattern: &str) -> PolarsResult<Self> {
+        RegexBuilder::new(pattern)
+            .unicode(true)
+            .case_insensitive(false)
+            .multi_line(false)
+            .dot_matches_new_line(false)
+            .crlf(false)
+            .swap_greed(false)
+            .ignore_whitespace(false)
+            .octal(false)
+            .build()
+            .map_err(|e| PolarsError::ComputeError(e.to_string().into()))
+    }
+
+    fn is_match(&self, text: &str) -> bool {
+        self.is_match(text)
+    }
+
+    fn find<'t>(&self, text: &'t str) -> Option<Match<'t>> {
+        self.find(text).map(|m| Match {
+            text: m.as_str(),
+            start: m.start(),
+            end: m.end(),
+        })
+    }
+
+    fn find_iter<'t>(&'t self, text: &'t str) -> Box<dyn Iterator<Item = Match<'t>> + 't> {
+        Box::new(self.find_iter(text).map(|m| Match {
+            text: m.as_str(),
+            start: m.start(),
+            end: m.end(),
+        }))
+    }
+
+    fn replace<'t>(&self, text: &'t str, replacement: &str) -> Cow<'t, str> {
+        self.replace(text, replacement)
+    }
+
+    fn replace_all<'t>(&self, text: &'t str, replacement: &str) -> Cow<'t, str> {
+        self.replace_all(text, replacement)
+    }
+
+    fn replace_all_literal<'t>(&self, text: &'t str, replacement: &str) -> Cow<'t, str> {
+        self.replace_all(text, RegexNoExpand(replacement))
+    }
+
+    fn captures<'t>(&self, text: &'t str) -> Option<CaptureGroups<'t>> {
+        self.captures(text)
+            .map(|caps| build_capture_groups(caps.len(), |i| caps.get(i).map(|m| m.as_str())))
+    }
+
+    fn captures_iter<'t>(
+        &'t self,
+        text: &'t str,
+    ) -> Box<dyn Iterator<Item = CaptureGroups<'t>> + 't> {
+        Box::new(
+            self.captures_iter(text)
+                .map(|caps| build_capture_groups(caps.len(), |i| caps.get(i).map(|m| m.as_str()))),
+        )
+    }
+
+    fn capture_names(&self) -> CaptureNamesIterator<'_> {
+        CaptureNamesIterator::Regex(regex::Regex::capture_names(self))
+    }
+
+    fn captures_len(&self) -> usize {
+        Regex::captures_len(self)
+    }
+
+    fn count_matches(&self, text: &str) -> usize {
+        regex::Regex::find_iter(self, text).count()
+    }
+}
+
+/// Helper to build a literal replacement result from an iterator of match spans.
+/// When a zero-width match occurs at the end of the string, advance beyond the end to signal termination.
+fn replace_all_literal_from_spans<'t, I>(text: &'t str, replacement: &str, spans: I) -> Cow<'t, str>
+where
+    I: IntoIterator<Item = (usize, usize)>,
+{
+    let mut result = String::with_capacity(text.len() + replacement.len() * 2);
+    let mut last_end = 0;
+    let mut has_matches = false;
+
+    for (start, end) in spans {
+        has_matches = true;
+        result.push_str(&text[last_end..start]);
+        result.push_str(replacement);
+        last_end = end;
+    }
+
+    if has_matches {
+        result.push_str(&text[last_end..]);
+        Cow::Owned(result)
+    } else {
+        Cow::Borrowed(text)
+    }
+}
+
+macro_rules! dispatch {
+    ($self:expr, $method:ident $(, $args:expr)*) => {
+        match $self {
+            RegexAdapter::Regex(re) => <Regex as RegexTrait>::$method(re, $($args),*),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum RegexAdapter {
+    Regex(Regex),
+}
+
+impl RegexAdapter {
+    pub fn is_match(&self, text: &str) -> bool {
+        dispatch!(self, is_match, text)
+    }
+
+    pub fn find<'t>(&self, text: &'t str) -> Option<Match<'t>> {
+        dispatch!(self, find, text)
+    }
+
+    pub fn find_iter<'t>(&'t self, text: &'t str) -> Box<dyn Iterator<Item = Match<'t>> + 't> {
+        dispatch!(self, find_iter, text)
+    }
+
+    pub fn replace<'t>(&self, text: &'t str, replacement: &str) -> std::borrow::Cow<'t, str> {
+        dispatch!(self, replace, text, replacement)
+    }
+
+    pub fn replace_all<'t>(&self, text: &'t str, replacement: &str) -> std::borrow::Cow<'t, str> {
+        dispatch!(self, replace_all, text, replacement)
+    }
+
+    pub fn replace_all_literal<'t>(
+        &self,
+        text: &'t str,
+        replacement: &str,
+    ) -> std::borrow::Cow<'t, str> {
+        dispatch!(self, replace_all_literal, text, replacement)
+    }
+
+    pub fn captures<'t>(&self, text: &'t str) -> Option<CaptureGroups<'t>> {
+        dispatch!(self, captures, text)
+    }
+
+    pub fn captures_iter<'t>(
+        &'t self,
+        text: &'t str,
+    ) -> Box<dyn Iterator<Item = CaptureGroups<'t>> + 't> {
+        dispatch!(self, captures_iter, text)
+    }
+
+    pub fn capture_names(&self) -> CaptureNamesIterator<'_> {
+        dispatch!(self, capture_names)
+    }
+
+    pub fn captures_len(&self) -> usize {
+        dispatch!(self, captures_len)
+    }
+
+    pub fn count_matches(&self, text: &str) -> usize {
+        dispatch!(self, count_matches, text)
+    }
+}
+
+#[derive(Default)]
+pub struct CaptureLocationsBuffer {
+    locations: Option<LocationsInner>,
+}
+
+enum LocationsInner {
+    Regex(RegexCaptureLocations),
+}
+
+impl CaptureLocationsBuffer {
+    fn regex_locations_mut(&mut self) -> Option<&mut RegexCaptureLocations> {
+        match self.locations {
+            Some(LocationsInner::Regex(ref mut locs)) => Some(locs),
+            _ => None,
+        }
+    }
+}
+
+impl RegexAdapter {
+    pub fn create_locations_buffer(&self) -> CaptureLocationsBuffer {
+        match self {
+            RegexAdapter::Regex(re) => CaptureLocationsBuffer {
+                locations: Some(LocationsInner::Regex(re.capture_locations())),
+            },
+        }
+    }
+
+    pub fn captures_with_buffer<'t, 'b>(
+        &'t self,
+        text: &'t str,
+        buffer: &'b mut CaptureLocationsBuffer,
+    ) -> Option<FastCaptureResult<'t, 'b>> {
+        match self {
+            RegexAdapter::Regex(re) => {
+                if let Some(locs) = buffer.regex_locations_mut() {
+                    if re.captures_read(locs, text).is_some() {
+                        return Some(FastCaptureResult::RegexLocations(text, locs));
+                    }
+                }
+                None
+            },
+        }
+    }
+
+    pub fn get_group_with_buffer<'t>(
+        &'t self,
+        text: &'t str,
+        group_index: usize,
+        buffer: &mut CaptureLocationsBuffer,
+    ) -> Option<&'t str> {
+        match self {
+            RegexAdapter::Regex(re) => {
+                if let Some(locs) = buffer.regex_locations_mut() {
+                    if re.captures_read(locs, text).is_some() {
+                        return locs.get(group_index).map(|(start, end)| &text[start..end]);
+                    }
+                }
+                None
+            },
+        }
+    }
+}
+
+pub enum FastCaptureResult<'t, 'b> {
+    RegexLocations(&'t str, &'b regex::CaptureLocations),
+}
+
+impl<'t, 'b> FastCaptureResult<'t, 'b> {
+    /// Get a capture group by index
+    pub fn get(&self, index: usize) -> Option<&'t str> {
+        match self {
+            FastCaptureResult::RegexLocations(text, locs) => {
+                locs.get(index).map(|(start, end)| &text[start..end])
+            },
+        }
+    }
+}

--- a/crates/polars-utils/src/regex_cache.rs
+++ b/crates/polars-utils/src/regex_cache.rs
@@ -1,32 +1,48 @@
 use std::cell::RefCell;
 
+use polars_error::{PolarsError, PolarsResult};
 use regex::Regex;
 
 use crate::cache::LruCache;
+use crate::regex_adapter::RegexAdapter;
+pub use crate::regex_adapter::RegexEngine;
 
 // Regex compilation is really heavy, and the resulting regexes can be large as
 // well, so we should have a good caching scheme.
 //
 // TODO: add larger global cache which has time-based flush.
 
-/// A cache for compiled regular expressions.
+/// A multi-engine cache for runtime-compiled regular expressions
 pub struct RegexCache {
-    cache: LruCache<String, Regex>,
+    regex_cache: LruCache<String, Regex>,
 }
 
 impl RegexCache {
     fn new() -> Self {
         Self {
-            cache: LruCache::with_capacity(32),
+            regex_cache: LruCache::with_capacity(32),
         }
     }
 
-    pub fn compile(&mut self, re: &str) -> Result<&Regex, regex::Error> {
-        let r = self.cache.try_get_or_insert_with(re, |re| {
+    pub fn compile_regex(&mut self, re: &str) -> Result<&Regex, regex::Error> {
+        let r = self.regex_cache.try_get_or_insert_with(re, |re| {
             #[allow(clippy::disallowed_methods)]
             Regex::new(re)
         });
         Ok(&*r?)
+    }
+
+    pub fn compile_adapter(
+        &mut self,
+        re_str: &str,
+        engine: RegexEngine,
+    ) -> PolarsResult<RegexAdapter> {
+        match engine {
+            RegexEngine::Regex => self
+                .compile_regex(re_str)
+                .map(|re| RegexAdapter::Regex(re.clone()))
+                .map_err(|e| PolarsError::ComputeError(e.to_string().into())),
+        }
     }
 }
 
@@ -34,8 +50,8 @@ thread_local! {
     static LOCAL_REGEX_CACHE: RefCell<RegexCache> = RefCell::new(RegexCache::new());
 }
 
-pub fn compile_regex(re: &str) -> Result<Regex, regex::Error> {
-    LOCAL_REGEX_CACHE.with_borrow_mut(|cache| cache.compile(re).cloned())
+pub fn compile_regex(re: &str, engine: RegexEngine) -> PolarsResult<RegexAdapter> {
+    LOCAL_REGEX_CACHE.with_borrow_mut(|cache| cache.compile_adapter(re, engine))
 }
 
 pub fn with_regex_cache<R, F: FnOnce(&mut RegexCache) -> R>(f: F) -> R {

--- a/crates/polars/tests/it/lazy/expressions/arity.rs
+++ b/crates/polars/tests/it/lazy/expressions/arity.rs
@@ -57,7 +57,7 @@ fn includes_null_predicate_3038() -> PolarsResult<()> {
                 move |s| {
                     s.str()?
                         .to_lowercase()
-                        .contains("not_exist", true)
+                        .contains("not_exist", true, Default::default())
                         .map(|ca| Some(ca.into_column()))
                 },
                 GetOutput::from_type(DataType::Boolean),

--- a/docs/source/src/rust/user-guide/expressions/strings.rs
+++ b/docs/source/src/rust/user-guide/expressions/strings.rs
@@ -29,8 +29,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .str()
                 .starts_with(lit("p"))
                 .alias("starts_with_p"),
-            col("fruit").str().contains(lit("p..r"), true).alias("p..r"),
-            col("fruit").str().contains(lit("e+"), true).alias("e+"),
+            col("fruit")
+                .str()
+                .contains(lit("p..r"), true, Default::default())
+                .alias("p..r"),
+            col("fruit")
+                .str()
+                .contains(lit("e+"), true, Default::default())
+                .alias("e+"),
             col("fruit").str().ends_with(lit("r")).alias("ends_with_r"),
         ])
         .collect()?;
@@ -50,7 +56,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let result = df
         .clone()
         .lazy()
-        .select([col("urls").str().extract(lit(r"candidate=(\w+)"), 1)])
+        .select([col("urls")
+            .str()
+            .extract(lit(r"candidate=(\w+)"), 1, Default::default())])
         .collect()?;
 
     println!("{}", result);
@@ -66,7 +74,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .lazy()
         .select([col("text")
             .str()
-            .extract_all(lit(r"(\d+)"))
+            .extract_all(lit(r"(\d+)"), Default::default())
             .alias("extracted_nrs")])
         .collect()?;
 
@@ -82,10 +90,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .clone()
         .lazy()
         .with_columns([
-            col("text").str().replace(lit(r"\d"), lit("-"), false),
             col("text")
                 .str()
-                .replace_all(lit(r"\d"), lit("-"), false)
+                .replace(lit(r"\d"), lit("-"), false, Default::default()),
+            col("text")
+                .str()
+                .replace_all(lit(r"\d"), lit("-"), false, Default::default())
                 .alias("text_replace_all"),
         ])
         .collect()?;

--- a/docs/source/src/rust/user-guide/expressions/structs.rs
+++ b/docs/source/src/rust/user-guide/expressions/structs.rs
@@ -127,8 +127,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // note: the `'solution_map_elements'` alias is just there to show how you
                 // get the same output as in the Python API example.
                 .alias("solution_map_elements"),
-            (col("keys").str().count_matches(lit("."), true) + col("values"))
-                .alias("solution_expr"),
+            (col("keys")
+                .str()
+                .count_matches(lit("."), true, Default::default())
+                + col("values"))
+            .alias("solution_expr"),
         ])
         .collect()?;
     println!("{}", result);


### PR DESCRIPTION
Add the `engine` parameter to regex-compatible `str` methods:
- contains
- count_matches
- extract
- extract_all
- extract_groups
- find
- replace
- replace_all
Introduce `RegexEngine` Enum (default: `Regex`, the `regex` crate)