### PR TITLE
feat(python): Implement regex engine selection

### DIFF
--- a/crates/polars-python/src/expr/string.rs
+++ b/crates/polars-python/src/expr/string.rs
@@ -1,4 +1,5 @@
 use polars::prelude::*;
+use polars_utils::regex_cache::RegexEngine;
 use pyo3::prelude::*;
 
 use crate::PyExpr;
@@ -139,20 +140,33 @@ impl PyExpr {
     }
 
     #[cfg(feature = "regex")]
-    fn str_replace_n(&self, pat: Self, val: Self, literal: bool, n: i64) -> Self {
+    fn str_replace_n(
+        &self,
+        pat: Self,
+        val: Self,
+        literal: bool,
+        n: i64,
+        engine: Wrap<RegexEngine>,
+    ) -> Self {
         self.inner
             .clone()
             .str()
-            .replace_n(pat.inner, val.inner, literal, n, Default::default())
+            .replace_n(pat.inner, val.inner, literal, n, engine.0)
             .into()
     }
 
     #[cfg(feature = "regex")]
-    fn str_replace_all(&self, pat: Self, val: Self, literal: bool) -> Self {
+    fn str_replace_all(
+        &self,
+        pat: Self,
+        val: Self,
+        literal: bool,
+        engine: Wrap<RegexEngine>,
+    ) -> Self {
         self.inner
             .clone()
             .str()
-            .replace_all(pat.inner, val.inner, literal, Default::default())
+            .replace_all(pat.inner, val.inner, literal, engine.0)
             .into()
     }
 
@@ -176,30 +190,42 @@ impl PyExpr {
         self.inner.clone().str().zfill(length.inner).into()
     }
 
-    #[pyo3(signature = (pat, literal, strict))]
+    #[pyo3(signature = (pat, literal, strict, engine))]
     #[cfg(feature = "regex")]
-    fn str_contains(&self, pat: Self, literal: Option<bool>, strict: bool) -> Self {
+    fn str_contains(
+        &self,
+        pat: Self,
+        literal: Option<bool>,
+        strict: bool,
+        engine: Wrap<RegexEngine>,
+    ) -> Self {
         match literal {
             Some(true) => self.inner.clone().str().contains_literal(pat.inner).into(),
             _ => self
                 .inner
                 .clone()
                 .str()
-                .contains(pat.inner, strict, Default::default())
+                .contains(pat.inner, strict, engine.0)
                 .into(),
         }
     }
 
-    #[pyo3(signature = (pat, literal, strict))]
+    #[pyo3(signature = (pat, literal, strict, engine))]
     #[cfg(feature = "regex")]
-    fn str_find(&self, pat: Self, literal: Option<bool>, strict: bool) -> Self {
+    fn str_find(
+        &self,
+        pat: Self,
+        literal: Option<bool>,
+        strict: bool,
+        engine: Wrap<RegexEngine>,
+    ) -> Self {
         match literal {
             Some(true) => self.inner.clone().str().find_literal(pat.inner).into(),
             _ => self
                 .inner
                 .clone()
                 .str()
-                .find(pat.inner, strict, Default::default())
+                .find(pat.inner, strict, engine.0)
                 .into(),
         }
     }
@@ -259,38 +285,38 @@ impl PyExpr {
         self.inner.clone().str().json_path_match(pat.inner).into()
     }
 
-    fn str_extract(&self, pat: Self, group_index: usize) -> Self {
+    fn str_extract(&self, pat: Self, group_index: usize, engine: Wrap<RegexEngine>) -> Self {
         self.inner
             .clone()
             .str()
-            .extract(pat.inner, group_index, Default::default())
+            .extract(pat.inner, group_index, engine.0)
             .into()
     }
 
-    fn str_extract_all(&self, pat: Self) -> Self {
+    fn str_extract_all(&self, pat: Self, engine: Wrap<RegexEngine>) -> Self {
         self.inner
             .clone()
             .str()
-            .extract_all(pat.inner, Default::default())
+            .extract_all(pat.inner, engine.0)
             .into()
     }
 
     #[cfg(feature = "extract_groups")]
-    fn str_extract_groups(&self, pat: &str) -> PyResult<Self> {
+    fn str_extract_groups(&self, pat: &str, engine: Wrap<RegexEngine>) -> PyResult<Self> {
         Ok(self
             .inner
             .clone()
             .str()
-            .extract_groups(pat, Default::default())
+            .extract_groups(pat, engine.0)
             .map_err(PyPolarsErr::from)?
             .into())
     }
 
-    fn str_count_matches(&self, pat: Self, literal: bool) -> Self {
+    fn str_count_matches(&self, pat: Self, literal: bool, engine: Wrap<RegexEngine>) -> Self {
         self.inner
             .clone()
             .str()
-            .count_matches(pat.inner, literal, Default::default())
+            .count_matches(pat.inner, literal, engine.0)
             .into()
     }
 

--- a/py-polars/fancy_polars/_typing.py
+++ b/py-polars/fancy_polars/_typing.py
@@ -134,6 +134,7 @@ PivotAgg: TypeAlias = Literal[
     "min", "max", "first", "last", "sum", "mean", "median", "len"
 ]
 RankMethod: TypeAlias = Literal["average", "min", "max", "dense", "ordinal", "random"]
+RegexEngine: TypeAlias = Literal["regex"]
 Roll: TypeAlias = Literal["raise", "forward", "backward"]
 RoundMode: TypeAlias = Literal["half_to_even", "half_away_from_zero"]
 SerializationFormat: TypeAlias = Literal["binary", "json"]

--- a/py-polars/fancy_polars/expr/string.py
+++ b/py-polars/fancy_polars/expr/string.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
         IntoExprColumn,
         PolarsDataType,
         PolarsTemporalType,
+        RegexEngine,
         TimeUnit,
         TransferEncoding,
         UnicodeForm,
@@ -932,7 +933,12 @@ class ExprStringNameSpace:
         return wrap_expr(self._pyexpr.str_zfill(length))
 
     def contains(
-        self, pattern: str | Expr, *, literal: bool = False, strict: bool = True
+        self,
+        pattern: str | Expr,
+        *,
+        literal: bool = False,
+        strict: bool = True,
+        engine: RegexEngine = "regex",
     ) -> Expr:
         """
         Check if the string contains a substring that matches a pattern.
@@ -947,6 +953,8 @@ class ExprStringNameSpace:
         strict
             Raise an error if the underlying pattern is not a valid regex,
             otherwise mask out with a null value.
+        engine, optional
+            The regex engine to use, by default "regex".
 
         Notes
         -----
@@ -999,10 +1007,15 @@ class ExprStringNameSpace:
         └─────────────┴───────┴─────────┘
         """
         pattern = parse_into_expression(pattern, str_as_lit=True)
-        return wrap_expr(self._pyexpr.str_contains(pattern, literal, strict))
+        return wrap_expr(self._pyexpr.str_contains(pattern, literal, strict, engine))
 
     def find(
-        self, pattern: str | Expr, *, literal: bool = False, strict: bool = True
+        self,
+        pattern: str | Expr,
+        *,
+        literal: bool = False,
+        strict: bool = True,
+        engine: RegexEngine = "regex",
     ) -> Expr:
         """
         Return the bytes offset of the first substring matching a pattern.
@@ -1019,6 +1032,8 @@ class ExprStringNameSpace:
         strict
             Raise an error if the underlying pattern is not a valid regex,
             otherwise mask out with a null value.
+        engine, optional
+            The regex engine to use, by default "regex".
 
         Notes
         -----
@@ -1092,7 +1107,7 @@ class ExprStringNameSpace:
         └────────────┴───────────┴──────────┘
         """
         pattern = parse_into_expression(pattern, str_as_lit=True)
-        return wrap_expr(self._pyexpr.str_find(pattern, literal, strict))
+        return wrap_expr(self._pyexpr.str_find(pattern, literal, strict, engine))
 
     def ends_with(self, suffix: str | Expr) -> Expr:
         """
@@ -1387,7 +1402,12 @@ class ExprStringNameSpace:
             msg = f"`encoding` must be one of {{'hex', 'base64'}}, got {encoding!r}"
             raise ValueError(msg)
 
-    def extract(self, pattern: IntoExprColumn, group_index: int = 1) -> Expr:
+    def extract(
+        self,
+        pattern: IntoExprColumn,
+        group_index: int = 1,
+        engine: RegexEngine = "regex",
+    ) -> Expr:
         r"""
         Extract the target capture group from provided patterns.
 
@@ -1400,6 +1420,8 @@ class ExprStringNameSpace:
             Index of the targeted capture group.
             Group 0 means the whole pattern, the first group begins at index 1.
             Defaults to the first capture group.
+        engine, optional
+            The regex engine to use, by default "regex".
 
         Notes
         -----
@@ -1468,9 +1490,9 @@ class ExprStringNameSpace:
         └───────────┴─────────┴───────┘
         """
         pattern = parse_into_expression(pattern, str_as_lit=True)
-        return wrap_expr(self._pyexpr.str_extract(pattern, group_index))
+        return wrap_expr(self._pyexpr.str_extract(pattern, group_index, engine))
 
-    def extract_all(self, pattern: str | Expr) -> Expr:
+    def extract_all(self, pattern: str | Expr, engine: RegexEngine = "regex") -> Expr:
         r'''
         Extract all matches for the given regex pattern.
 
@@ -1482,6 +1504,8 @@ class ExprStringNameSpace:
         pattern
             A valid regular expression pattern, compatible with the `regex crate
             <https://docs.rs/regex/latest/regex/>`_.
+        engine, optional
+            The regex engine to use, by default "regex".
 
         Notes
         -----
@@ -1554,9 +1578,9 @@ class ExprStringNameSpace:
 
         '''
         pattern = parse_into_expression(pattern, str_as_lit=True)
-        return wrap_expr(self._pyexpr.str_extract_all(pattern))
+        return wrap_expr(self._pyexpr.str_extract_all(pattern, engine))
 
-    def extract_groups(self, pattern: str) -> Expr:
+    def extract_groups(self, pattern: str, engine: RegexEngine = "regex") -> Expr:
         r"""
         Extract all capture groups for the given regex pattern.
 
@@ -1565,6 +1589,8 @@ class ExprStringNameSpace:
         pattern
             A valid regular expression pattern containing at least one capture group,
             compatible with the `regex crate <https://docs.rs/regex/latest/regex/>`_.
+        engine, optional
+            The regex engine to use, by default "regex".
 
         Notes
         -----
@@ -1644,9 +1670,15 @@ class ExprStringNameSpace:
         if not isinstance(pattern, str):
             msg = f"extract_groups expects a `str`, given a {qualified_type_name(pattern)!r}"
             raise TypeError(msg)
-        return wrap_expr(self._pyexpr.str_extract_groups(pattern))
+        return wrap_expr(self._pyexpr.str_extract_groups(pattern, engine))
 
-    def count_matches(self, pattern: str | Expr, *, literal: bool = False) -> Expr:
+    def count_matches(
+        self,
+        pattern: str | Expr,
+        *,
+        literal: bool = False,
+        engine: RegexEngine = "regex",
+    ) -> Expr:
         r"""
         Count all successive non-overlapping regex matches.
 
@@ -1657,6 +1689,8 @@ class ExprStringNameSpace:
             <https://docs.rs/regex/latest/regex/>`_.
         literal
             Treat `pattern` as a literal string, not as a regular expression.
+        engine, optional
+            The regex engine to use, by default "regex".
 
         Returns
         -------
@@ -1701,7 +1735,7 @@ class ExprStringNameSpace:
         └────────────┴──────────────┘
         """
         pattern = parse_into_expression(pattern, str_as_lit=True)
-        return wrap_expr(self._pyexpr.str_count_matches(pattern, literal))
+        return wrap_expr(self._pyexpr.str_count_matches(pattern, literal, engine))
 
     def split(self, by: IntoExpr, *, inclusive: bool = False) -> Expr:
         """
@@ -1898,6 +1932,7 @@ class ExprStringNameSpace:
         *,
         literal: bool = False,
         n: int = 1,
+        engine: RegexEngine = "regex",
     ) -> Expr:
         r"""
         Replace first matching regex/literal substring with a new string value.
@@ -1913,6 +1948,8 @@ class ExprStringNameSpace:
             Treat `pattern` as a literal string.
         n
             Number of matches to replace.
+        engine, optional
+            The regex engine to use, by default "regex".
 
         See Also
         --------
@@ -2010,10 +2047,15 @@ class ExprStringNameSpace:
         """
         pattern = parse_into_expression(pattern, str_as_lit=True)
         value = parse_into_expression(value, str_as_lit=True)
-        return wrap_expr(self._pyexpr.str_replace_n(pattern, value, literal, n))
+        return wrap_expr(self._pyexpr.str_replace_n(pattern, value, literal, n, engine))
 
     def replace_all(
-        self, pattern: str | Expr, value: str | Expr, *, literal: bool = False
+        self,
+        pattern: str | Expr,
+        value: str | Expr,
+        *,
+        literal: bool = False,
+        engine: RegexEngine = "regex",
     ) -> Expr:
         r"""
         Replace all matching regex/literal substrings with a new string value.
@@ -2027,6 +2069,8 @@ class ExprStringNameSpace:
             String that will replace the matched substring.
         literal
             Treat `pattern` as a literal string.
+        engine, optional
+            The regex engine to use, by default "regex".
 
         See Also
         --------
@@ -2130,7 +2174,7 @@ class ExprStringNameSpace:
         """
         pattern = parse_into_expression(pattern, str_as_lit=True)
         value = parse_into_expression(value, str_as_lit=True)
-        return wrap_expr(self._pyexpr.str_replace_all(pattern, value, literal))
+        return wrap_expr(self._pyexpr.str_replace_all(pattern, value, literal, engine))
 
     def reverse(self) -> Expr:
         """

--- a/py-polars/fancy_polars/series/string.py
+++ b/py-polars/fancy_polars/series/string.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
         IntoExprColumn,
         PolarsDataType,
         PolarsTemporalType,
+        RegexEngine,
         TimeUnit,
         TransferEncoding,
         UnicodeForm,
@@ -382,7 +383,12 @@ class StringNameSpace:
         """
 
     def contains(
-        self, pattern: str | Expr, *, literal: bool = False, strict: bool = True
+        self,
+        pattern: str | Expr,
+        *,
+        literal: bool = False,
+        strict: bool = True,
+        engine: RegexEngine = "regex",
     ) -> Series:
         """
         Check if the string contains a substring that matches a pattern.
@@ -397,6 +403,8 @@ class StringNameSpace:
         strict
             Raise an error if the underlying pattern is not a valid regex,
             otherwise mask out with a null value.
+        engine, optional
+            The regex engine to use, by default "regex".
 
         Notes
         -----
@@ -448,7 +456,12 @@ class StringNameSpace:
         """
 
     def find(
-        self, pattern: str | Expr, *, literal: bool = False, strict: bool = True
+        self,
+        pattern: str | Expr,
+        *,
+        literal: bool = False,
+        strict: bool = True,
+        engine: RegexEngine = "regex",
     ) -> Series:
         """
         Return the bytes offset of the first substring matching a pattern.
@@ -465,6 +478,8 @@ class StringNameSpace:
         strict
             Raise an error if the underlying pattern is not a valid regex,
             otherwise mask out with a null value.
+        engine, optional
+            The regex engine to use, by default "regex".
 
         Notes
         -----
@@ -720,7 +735,12 @@ class StringNameSpace:
         ]
         """
 
-    def extract(self, pattern: IntoExprColumn, group_index: int = 1) -> Series:
+    def extract(
+        self,
+        pattern: IntoExprColumn,
+        group_index: int = 1,
+        engine: RegexEngine = "regex",
+    ) -> Series:
         r"""
         Extract the target capture group from provided patterns.
 
@@ -733,6 +753,8 @@ class StringNameSpace:
             Index of the targeted capture group.
             Group 0 means the whole pattern, the first group begins at index 1.
             Defaults to the first capture group.
+        engine, optional
+            The regex engine to use, by default "regex".
 
         Returns
         -------
@@ -784,7 +806,9 @@ class StringNameSpace:
         ]
         """
 
-    def extract_all(self, pattern: str | Series) -> Series:
+    def extract_all(
+        self, pattern: str | Series, engine: RegexEngine = "regex"
+    ) -> Series:
         r'''
         Extract all matches for the given regex pattern.
 
@@ -796,6 +820,8 @@ class StringNameSpace:
         pattern
             A valid regular expression pattern, compatible with the `regex crate
             <https://docs.rs/regex/latest/regex/>`_.
+        engine, optional
+            The regex engine to use, by default "regex".
 
         Notes
         -----
@@ -854,7 +880,7 @@ class StringNameSpace:
 
         '''
 
-    def extract_groups(self, pattern: str) -> Series:
+    def extract_groups(self, pattern: str, engine: RegexEngine = "regex") -> Series:
         r"""
         Extract all capture groups for the given regex pattern.
 
@@ -863,6 +889,8 @@ class StringNameSpace:
         pattern
             A valid regular expression pattern containing at least one capture group,
             compatible with the `regex crate <https://docs.rs/regex/latest/regex/>`_.
+        engine, optional
+            The regex engine to use, by default "regex".
 
         Notes
         -----
@@ -910,7 +938,13 @@ class StringNameSpace:
         ]
         """
 
-    def count_matches(self, pattern: str | Series, *, literal: bool = False) -> Series:
+    def count_matches(
+        self,
+        pattern: str | Series,
+        *,
+        literal: bool = False,
+        engine: RegexEngine = "regex",
+    ) -> Series:
         r"""
         Count all successive non-overlapping regex matches.
 
@@ -922,6 +956,8 @@ class StringNameSpace:
             regular expressions.
         literal
             Treat `pattern` as a literal string, not as a regular expression.
+        engine, optional
+            The regex engine to use, by default "regex".
 
         Returns
         -------
@@ -1091,7 +1127,13 @@ class StringNameSpace:
         """
 
     def replace(
-        self, pattern: str, value: str, *, literal: bool = False, n: int = 1
+        self,
+        pattern: str,
+        value: str,
+        *,
+        literal: bool = False,
+        n: int = 1,
+        engine: RegexEngine = "regex",
     ) -> Series:
         r"""
         Replace first matching regex/literal substring with a new string value.
@@ -1107,6 +1149,8 @@ class StringNameSpace:
             Treat `pattern` as a literal string.
         n
             Number of matches to replace.
+        engine, optional
+            The regex engine to use, by default "regex".
 
         See Also
         --------
@@ -1199,7 +1243,14 @@ class StringNameSpace:
         ]
         """
 
-    def replace_all(self, pattern: str, value: str, *, literal: bool = False) -> Series:
+    def replace_all(
+        self,
+        pattern: str,
+        value: str,
+        *,
+        literal: bool = False,
+        engine: RegexEngine = "regex",
+    ) -> Series:
         r"""
         Replace all matching regex/literal substrings with a new string value.
 
@@ -1212,6 +1263,8 @@ class StringNameSpace:
             String that will replace the matched substring.
         literal
             Treat `pattern` as a literal string.
+        engine, optional
+            The regex engine to use, by default "regex".
 
         See Also
         --------


### PR DESCRIPTION
Add the engine parameter (default: "regex") to regex-compatible str methods:
- contains
- count_matches
- extract
- extract_all
- extract_groups
- find
- replace
- replace_all
