### PR TITLE
feat(rust): Integrate `pcre2` regex engine

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -82,6 +82,10 @@ jobs:
           ln -sv \
             $(python -c "import importlib; print(importlib.util.find_spec('fancy_polars').submodule_search_locations[0] + '/fancy_polars.abi3.so')") \
             py-polars/fancy_polars/fancy_polars.abi3.so
+          # Also symlink the vendored shared libs (e.g. PCRE2)
+          ln -sfn \
+            $(python -c "import importlib, os; pkg = importlib.util.find_spec('fancy_polars').submodule_search_locations[0]; print(os.path.join(os.path.dirname(pkg), 'fancy_polars.libs'))") \
+            py-polars/fancy_polars.libs
 
       - name: Set wheel size
         run: |

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -329,7 +329,7 @@ jobs:
 
       - name: Disable incompatible features
         env:
-            FEATURES: parquet|async|json|extract_jsonpath|catalog|cloud|polars_cloud|tokio|clipboard|decompress|new_streaming
+            FEATURES: pcre2|parquet|async|json|extract_jsonpath|catalog|cloud|polars_cloud|tokio|clipboard|decompress|new_streaming
         run: |
           sed -i 's/^  "json",$/  "serde_json",/' crates/polars-python/Cargo.toml
           sed -E -i "/^  \"(${FEATURES})\",$/d" crates/polars-python/Cargo.toml py-polars/Cargo.toml

--- a/.github/workflows/test-pyodide.yml
+++ b/.github/workflows/test-pyodide.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Disable incompatible features
         env:
           # Note: If you change this line, you must also copy the change to `release-python.yml`.
-          FEATURES: parquet|async|json|extract_jsonpath|catalog|cloud|polars_cloud|tokio|clipboard|decompress|new_streaming
+          FEATURES: pcre2|parquet|async|json|extract_jsonpath|catalog|cloud|polars_cloud|tokio|clipboard|decompress|new_streaming
         run: |
           sed -i 's/^  "json",$/  "serde_json",/' crates/polars-python/Cargo.toml
           sed -E -i "/^  \"(${FEATURES})\",$/d" crates/polars-python/Cargo.toml py-polars/Cargo.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2908,6 +2908,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pcre2"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be55c43ac18044541d58d897e8f4c55157218428953ebd39d86df3ba0286b2b"
+dependencies = [
+ "libc",
+ "log",
+ "pcre2-sys",
+]
+
+[[package]]
+name = "pcre2-sys"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "550f5d18fb1b90c20b87e161852c10cde77858c3900c5059b5ad2a1449f11d8a"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3660,6 +3682,7 @@ dependencies = [
  "libc",
  "memmap2",
  "num-traits",
+ "pcre2",
  "polars-error",
  "pyo3",
  "rand",

--- a/crates/Makefile
+++ b/crates/Makefile
@@ -157,6 +157,7 @@ check-wasm:  ## Check wasm build without supported features
 		--exclude-features json               \
 		--exclude-features nightly            \
 		--exclude-features parquet            \
+		--exclude-features pcre2              \
 		--exclude-features performant         \
 		--exclude-features streaming          \
 		--exclude-features http               \

--- a/crates/polars-python/Cargo.toml
+++ b/crates/polars-python/Cargo.toml
@@ -123,6 +123,7 @@ version_check = { workspace = true }
 
 [features]
 # Features below are only there to enable building a slim binary during development.
+pcre2 = ["polars-utils/pcre2"]
 avro = ["polars/avro"]
 catalog = ["polars-lazy/catalog"]
 parquet = ["polars/parquet", "polars-parquet", "polars-mem-engine/parquet"]
@@ -269,6 +270,7 @@ all = [
   "ffi_plugin",
   "polars_cloud",
   "new_streaming",
+  "pcre2",
 ]
 
 # we cannot conditionally activate simd

--- a/crates/polars-utils/Cargo.toml
+++ b/crates/polars-utils/Cargo.toml
@@ -21,6 +21,7 @@ indexmap = { workspace = true }
 libc = { workspace = true }
 memmap = { workspace = true, optional = true }
 num-traits = { workspace = true }
+pcre2 = { version = "0.2.9", optional = true }
 polars-error = { workspace = true }
 pyo3 = { workspace = true, optional = true }
 rand = { workspace = true }
@@ -43,6 +44,7 @@ rand = { workspace = true }
 version_check = { workspace = true }
 
 [features]
+pcre2 = ["dep:pcre2"]
 mmap = ["memmap"]
 bigidx = []
 nightly = []

--- a/crates/polars-utils/src/regex_adapter.rs
+++ b/crates/polars-utils/src/regex_adapter.rs
@@ -2,12 +2,19 @@ use std::borrow::Cow;
 
 pub use fancy_regex::Regex as FancyRegex;
 use fancy_regex::RegexBuilder as FancyRegexBuilder;
+#[cfg(feature = "pcre2")]
+use pcre2::bytes::CaptureLocations as Pcre2CaptureLocations;
+#[cfg(feature = "pcre2")]
+pub use pcre2::bytes::{Regex as Pcre2Regex, RegexBuilder as Pcre2RegexBuilder};
 use polars_error::{PolarsError, PolarsResult};
 pub use regex::Regex;
 use regex::{CaptureLocations as RegexCaptureLocations, RegexBuilder};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use strum_macros::{AsRefStr, EnumString};
+
+#[cfg(feature = "pcre2")]
+use crate::aliases::PlHashMap;
 
 #[derive(AsRefStr, Clone, Copy, Debug, Default, EnumString, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -18,6 +25,9 @@ pub enum RegexEngine {
     Regex,
     // `fancy-regex` crate
     Fancy,
+    // `pcre2` crate
+    #[cfg(feature = "pcre2")]
+    Pcre2,
 }
 
 pub trait RegexTrait: Sized + Clone {
@@ -106,6 +116,8 @@ where
 pub enum CaptureNamesIterator<'a> {
     Regex(regex::CaptureNames<'a>),
     Fancy(fancy_regex::CaptureNames<'a>),
+    #[cfg(feature = "pcre2")]
+    Pcre2(std::slice::Iter<'a, Option<String>>),
 }
 
 impl<'a> Iterator for CaptureNamesIterator<'a> {
@@ -115,6 +127,8 @@ impl<'a> Iterator for CaptureNamesIterator<'a> {
         match self {
             CaptureNamesIterator::Regex(iter) => iter.next(),
             CaptureNamesIterator::Fancy(iter) => iter.next(),
+            #[cfg(feature = "pcre2")]
+            CaptureNamesIterator::Pcre2(iter) => iter.next().map(|opt| opt.as_deref()),
         }
     }
 }
@@ -386,11 +400,315 @@ impl RegexTrait for FancyRegex {
     }
 }
 
+#[cfg(feature = "pcre2")]
+impl RegexTrait for Pcre2Regex {
+    fn new(pattern: &str) -> PolarsResult<Self> {
+        let mut builder = Pcre2RegexBuilder::new();
+        builder
+            .caseless(false)
+            .dotall(false)
+            .extended(false)
+            .multi_line(false)
+            .crlf(false)
+            .ucp(true)
+            .utf(true)
+            .jit_if_available(true)
+            .build(pattern)
+            .map_err(|e| PolarsError::ComputeError(e.to_string().into()))
+    }
+
+    fn is_match(&self, text: &str) -> bool {
+        self.is_match(text.as_bytes()).unwrap_or(false)
+    }
+
+    fn find<'t>(&self, text: &'t str) -> Option<Match<'t>> {
+        self.find(text.as_bytes()).ok().flatten().map(|m| Match {
+            start: m.start(),
+            end: m.end(),
+            text: &text[m.start()..m.end()],
+        })
+    }
+
+    fn find_iter<'t>(&'t self, text: &'t str) -> Box<dyn Iterator<Item = Match<'t>> + 't> {
+        Box::new(
+            self.find_iter(text.as_bytes())
+                .filter_map(move |m| m.ok())
+                .map(move |m| Match {
+                    start: m.start(),
+                    end: m.end(),
+                    text: &text[m.start()..m.end()],
+                }),
+        )
+    }
+
+    fn replace<'t>(&self, text: &'t str, replacement: &str) -> Cow<'t, str> {
+        let replacer = build_pcre2_replacer(self, replacement);
+        pcre2_replace_impl(self, text, replacement, &replacer, false)
+    }
+
+    fn replace_all<'t>(&self, text: &'t str, replacement: &str) -> Cow<'t, str> {
+        let replacer = build_pcre2_replacer(self, replacement);
+        pcre2_replace_impl(self, text, replacement, &replacer, true)
+    }
+
+    fn captures<'t>(&self, text: &'t str) -> Option<CaptureGroups<'t>> {
+        self.captures(text.as_bytes()).ok().flatten().map(|caps| {
+            build_capture_groups(caps.len(), |i| {
+                caps.get(i).map(|m| &text[m.start()..m.end()])
+            })
+        })
+    }
+
+    fn capture_names(&self) -> CaptureNamesIterator<'_> {
+        CaptureNamesIterator::Pcre2(pcre2::bytes::Regex::capture_names(self).iter())
+    }
+
+    fn captures_len(&self) -> usize {
+        pcre2::bytes::Regex::captures_len(self)
+    }
+
+    fn count_matches(&self, text: &str) -> usize {
+        // Use the byte iterator directly and count successful matches, avoiding wrapper mapping.
+        self.find_iter(text.as_bytes())
+            .fold(0usize, |acc, res| acc + usize::from(res.is_ok()))
+    }
+}
+
+#[cfg(feature = "pcre2")]
+fn build_pcre2_replacer<'a>(re: &Pcre2Regex, replacement: &'a str) -> Pcre2Replacer<'a> {
+    let names_vec = pcre2::bytes::Regex::capture_names(re);
+    let caps_len = pcre2::bytes::Regex::captures_len(re);
+    Pcre2Replacer::new(replacement, caps_len, Some(names_vec))
+}
+
+#[cfg(feature = "pcre2")]
+fn pcre2_replace_impl<'t>(
+    re: &Pcre2Regex,
+    text: &'t str,
+    replacement: &str,
+    replacer: &Pcre2Replacer<'_>,
+    replace_all: bool,
+) -> Cow<'t, str> {
+    let mut result =
+        String::with_capacity(text.len() + replacement.len() * if replace_all { 4 } else { 1 });
+    let mut last_end = 0;
+    let mut has_matches = false;
+
+    let mut locs = re.capture_locations();
+
+    while last_end <= text.len() {
+        match re.captures_read_at(&mut locs, text.as_bytes(), last_end) {
+            Ok(Some(m)) => {
+                has_matches = true;
+                result.push_str(&text[last_end..m.start()]);
+                replacer.expand_into(&mut result, text, &locs);
+
+                let match_start = m.start();
+                let match_end = m.end();
+                if !replace_all {
+                    // For single replace, append the remainder starting from the end of the match.
+                    result.push_str(&text[match_end..]);
+                    return Cow::Owned(result);
+                }
+                last_end = advance_position(text, match_start, match_end);
+            },
+            _ => break,
+        }
+    }
+
+    if has_matches {
+        result.push_str(&text[last_end..]);
+        Cow::Owned(result)
+    } else {
+        Cow::Borrowed(text)
+    }
+}
+
+#[cfg(feature = "pcre2")]
+#[derive(Debug, Clone)]
+pub enum Pcre2ReplacementPart<'a> {
+    Literal(&'a str),
+    Capture(usize),
+}
+
+#[cfg(feature = "pcre2")]
+#[derive(Debug, Clone)]
+pub struct Pcre2Replacer<'a> {
+    parts: Vec<Pcre2ReplacementPart<'a>>,
+}
+
+#[cfg(feature = "pcre2")]
+impl<'a> Pcre2Replacer<'a> {
+    fn make_name_index(names_opt: Option<&[Option<String>]>) -> Option<PlHashMap<&'_ str, usize>> {
+        names_opt.map(|names| {
+            names
+                .iter()
+                .enumerate()
+                .filter_map(|(i, opt)| opt.as_deref().map(|name| (name, i)))
+                .collect()
+        })
+    }
+
+    fn resolve_capture_index(
+        key: &str,
+        caps_len: usize,
+        names_map: Option<&PlHashMap<&str, usize>>,
+    ) -> Option<usize> {
+        if let Ok(idx) = key.parse::<usize>() {
+            return (idx < caps_len).then_some(idx);
+        }
+        names_map
+            .and_then(|m| m.get(key).copied())
+            .filter(|&idx| idx < caps_len)
+    }
+
+    pub fn new(
+        replacement: &'a str,
+        caps_len: usize,
+        names_opt: Option<&[Option<String>]>,
+    ) -> Self {
+        if !replacement.contains('$') {
+            return Self {
+                parts: vec![Pcre2ReplacementPart::Literal(replacement)],
+            };
+        }
+
+        let names_map = Self::make_name_index(names_opt);
+
+        let mut parts = Vec::new();
+        let mut last_end = 0;
+        let mut chars = replacement.char_indices().peekable();
+
+        while let Some((i, ch)) = chars.next() {
+            if ch == '$' {
+                if i > last_end {
+                    parts.push(Pcre2ReplacementPart::Literal(&replacement[last_end..i]));
+                }
+                // we consumed '$'
+                last_end = i + 1;
+
+                match chars.peek() {
+                    Some(&(_, '$')) => {
+                        parts.push(Pcre2ReplacementPart::Literal("$"));
+                        chars.next(); // consume second '$'
+                        last_end += 1;
+                    },
+                    Some(&(_, '{')) => {
+                        chars.next(); // consume '{'
+                        let mut name = String::new();
+                        let mut end_index = i + 2; // after "${"
+                        while let Some(&(j, c)) = chars.peek() {
+                            end_index = j;
+                            if c == '}' {
+                                // consume '}'
+                                chars.next();
+                                end_index += 1; // position after '}'
+                                break;
+                            }
+                            name.push(c);
+                            chars.next();
+                        }
+                        let mut pushed = false;
+                        if let Some(idx) =
+                            Self::resolve_capture_index(&name, caps_len, names_map.as_ref())
+                        {
+                            parts.push(Pcre2ReplacementPart::Capture(idx));
+                            pushed = true;
+                        }
+                        // advance last_end to after closing brace if we saw one
+                        last_end = end_index;
+                        if !pushed {
+                            // if not resolved, treat token as empty (matches current numeric behavior)
+                        }
+                    },
+                    Some(&(_, c)) if c.is_ascii_digit() => {
+                        // $1, $12, etc
+                        let mut num_str = String::new();
+                        // consume first digit
+                        num_str.push(c);
+                        chars.next();
+                        while let Some(&(_, next_c)) = chars.peek() {
+                            if next_c.is_ascii_digit() {
+                                num_str.push(next_c);
+                                chars.next();
+                            } else {
+                                break;
+                            }
+                        }
+                        if let Some(idx) =
+                            Self::resolve_capture_index(&num_str, caps_len, names_map.as_ref())
+                        {
+                            parts.push(Pcre2ReplacementPart::Capture(idx));
+                        }
+                        last_end = i + 1 + num_str.len();
+                    },
+                    Some(&(_, c)) if c.is_ascii_alphabetic() || c == '_' => {
+                        // $name syntax: consume word chars [A-Za-z0-9_]*
+                        let mut name = String::new();
+                        // don't consume peeked char yet; read within loop
+                        while let Some(&(_, next_c)) = chars.peek() {
+                            if next_c.is_ascii_alphanumeric() || next_c == '_' {
+                                name.push(next_c);
+                                chars.next();
+                            } else {
+                                break;
+                            }
+                        }
+
+                        if !name.is_empty() {
+                            if let Some(idx) =
+                                Self::resolve_capture_index(&name, caps_len, names_map.as_ref())
+                            {
+                                parts.push(Pcre2ReplacementPart::Capture(idx));
+                            }
+                            // advance beyond $name
+                            last_end = i + 1 + name.len();
+                        } else {
+                            // treat as literal '$'
+                            parts.push(Pcre2ReplacementPart::Literal("$"));
+                        }
+                    },
+                    _ => {
+                        // not a recognized token, treat as literal '$'
+                        parts.push(Pcre2ReplacementPart::Literal("$"));
+                    },
+                }
+            }
+        }
+
+        if last_end < replacement.len() {
+            parts.push(Pcre2ReplacementPart::Literal(&replacement[last_end..]));
+        }
+
+        Self { parts }
+    }
+
+    pub fn expand_into(
+        &self,
+        result: &mut String,
+        text: &str,
+        locs: &pcre2::bytes::CaptureLocations,
+    ) {
+        for part in &self.parts {
+            match part {
+                Pcre2ReplacementPart::Literal(s) => result.push_str(s),
+                Pcre2ReplacementPart::Capture(idx) => {
+                    if let Some((start, end)) = locs.get(*idx) {
+                        result.push_str(&text[start..end]);
+                    }
+                },
+            }
+        }
+    }
+}
+
 macro_rules! dispatch {
     ($self:expr, $method:ident $(, $args:expr)*) => {
         match $self {
             RegexAdapter::Regex(re) => <Regex as RegexTrait>::$method(re, $($args),*),
             RegexAdapter::Fancy(re) => <FancyRegex as RegexTrait>::$method(re, $($args),*),
+            #[cfg(feature = "pcre2")]
+            RegexAdapter::Pcre2(re) => <Pcre2Regex as RegexTrait>::$method(re, $($args),*),
         }
     }
 }
@@ -399,6 +717,8 @@ macro_rules! dispatch {
 pub enum RegexAdapter {
     Regex(Regex),
     Fancy(FancyRegex),
+    #[cfg(feature = "pcre2")]
+    Pcre2(Pcre2Regex),
 }
 
 impl RegexAdapter {
@@ -446,12 +766,21 @@ pub struct CaptureLocationsBuffer {
 
 enum LocationsInner {
     Regex(RegexCaptureLocations),
+    #[cfg(feature = "pcre2")]
+    Pcre2(Pcre2CaptureLocations),
 }
 
 impl CaptureLocationsBuffer {
     fn regex_locations_mut(&mut self) -> Option<&mut RegexCaptureLocations> {
         match self.locations {
             Some(LocationsInner::Regex(ref mut locs)) => Some(locs),
+            _ => None,
+        }
+    }
+    #[cfg(feature = "pcre2")]
+    fn pcre2_locations_mut(&mut self) -> Option<&mut Pcre2CaptureLocations> {
+        match self.locations {
+            Some(LocationsInner::Pcre2(ref mut locs)) => Some(locs),
             _ => None,
         }
     }
@@ -464,6 +793,10 @@ impl RegexAdapter {
                 locations: Some(LocationsInner::Regex(re.capture_locations())),
             },
             RegexAdapter::Fancy(_) => CaptureLocationsBuffer::default(),
+            #[cfg(feature = "pcre2")]
+            RegexAdapter::Pcre2(re) => CaptureLocationsBuffer {
+                locations: Some(LocationsInner::Pcre2(re.capture_locations())),
+            },
         }
     }
 
@@ -484,6 +817,19 @@ impl RegexAdapter {
                 Ok(Some(caps)) => Some(FastCaptureResult::FancyCaps(caps)),
                 _ => None,
             },
+            #[cfg(feature = "pcre2")]
+            RegexAdapter::Pcre2(re) => buffer.pcre2_locations_mut().and_then(|locs| {
+                if re
+                    .captures_read_at(locs, text.as_bytes(), 0)
+                    .ok()
+                    .flatten()
+                    .is_some()
+                {
+                    Some(FastCaptureResult::Pcre2Locations(text, locs))
+                } else {
+                    None
+                }
+            }),
         }
     }
 
@@ -505,6 +851,19 @@ impl RegexAdapter {
                 Ok(Some(caps)) => caps.get(group_index).map(|m| m.as_str()),
                 _ => None,
             },
+            #[cfg(feature = "pcre2")]
+            RegexAdapter::Pcre2(re) => buffer.pcre2_locations_mut().and_then(|locs| {
+                if re
+                    .captures_read_at(locs, text.as_bytes(), 0)
+                    .ok()
+                    .flatten()
+                    .is_some()
+                {
+                    locs.get(group_index).map(|(start, end)| &text[start..end])
+                } else {
+                    None
+                }
+            }),
         }
     }
 }
@@ -512,6 +871,8 @@ impl RegexAdapter {
 pub enum FastCaptureResult<'t, 'b> {
     RegexLocations(&'t str, &'b regex::CaptureLocations),
     FancyCaps(fancy_regex::Captures<'t>),
+    #[cfg(feature = "pcre2")]
+    Pcre2Locations(&'t str, &'b pcre2::bytes::CaptureLocations),
 }
 
 impl<'t, 'b> FastCaptureResult<'t, 'b> {
@@ -522,6 +883,10 @@ impl<'t, 'b> FastCaptureResult<'t, 'b> {
                 locs.get(index).map(|(start, end)| &text[start..end])
             },
             FastCaptureResult::FancyCaps(caps) => caps.get(index).map(|m| m.as_str()),
+            #[cfg(feature = "pcre2")]
+            FastCaptureResult::Pcre2Locations(text, locs) => {
+                locs.get(index).map(|(start, end)| &text[start..end])
+            },
         }
     }
 }

--- a/crates/polars-utils/src/regex_cache.rs
+++ b/crates/polars-utils/src/regex_cache.rs
@@ -3,6 +3,8 @@ use std::cell::RefCell;
 use polars_error::PolarsResult;
 
 use crate::cache::LruCache;
+#[cfg(feature = "pcre2")]
+use crate::regex_adapter::Pcre2Regex;
 pub use crate::regex_adapter::RegexEngine;
 use crate::regex_adapter::{FancyRegex, Regex, RegexAdapter, RegexTrait};
 
@@ -15,6 +17,8 @@ use crate::regex_adapter::{FancyRegex, Regex, RegexAdapter, RegexTrait};
 pub struct RegexCache {
     regex_cache: LruCache<String, Regex>,
     fancy_cache: LruCache<String, FancyRegex>,
+    #[cfg(feature = "pcre2")]
+    pcre2_cache: LruCache<String, Pcre2Regex>,
 }
 
 impl RegexCache {
@@ -22,6 +26,8 @@ impl RegexCache {
         Self {
             regex_cache: LruCache::with_capacity(32),
             fancy_cache: LruCache::with_capacity(32),
+            #[cfg(feature = "pcre2")]
+            pcre2_cache: LruCache::with_capacity(32),
         }
     }
 
@@ -42,6 +48,13 @@ impl RegexCache {
                     .fancy_cache
                     .try_get_or_insert_with(re_str, <FancyRegex as RegexTrait>::new)?;
                 Ok(RegexAdapter::Fancy(re.clone()))
+            },
+            #[cfg(feature = "pcre2")]
+            RegexEngine::Pcre2 => {
+                let re = self
+                    .pcre2_cache
+                    .try_get_or_insert_with(re_str, <Pcre2Regex as RegexTrait>::new)?;
+                Ok(RegexAdapter::Pcre2(re.clone()))
             },
         }
     }

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -39,6 +39,7 @@ ipc = ["polars-python/ipc"]
 catalog = ["polars-python/catalog"]
 
 # Features passed through to the polars-python crate
+pcre2 = ["polars-python/pcre2"]
 avro = ["polars-python/avro"]
 ipc_streaming = ["polars-python/ipc_streaming"]
 is_in = ["polars-python/is_in"]
@@ -108,6 +109,7 @@ all = [
   "catalog",
   "polars-python/all",
   "performant",
+  "pcre2",
 ]
 
 default = ["all", "nightly"]

--- a/py-polars/fancy_polars/_typing.py
+++ b/py-polars/fancy_polars/_typing.py
@@ -134,7 +134,7 @@ PivotAgg: TypeAlias = Literal[
     "min", "max", "first", "last", "sum", "mean", "median", "len"
 ]
 RankMethod: TypeAlias = Literal["average", "min", "max", "dense", "ordinal", "random"]
-RegexEngine: TypeAlias = Literal["regex", "fancy"]
+RegexEngine: TypeAlias = Literal["regex", "fancy", "pcre2"]
 Roll: TypeAlias = Literal["raise", "forward", "backward"]
 RoundMode: TypeAlias = Literal["half_to_even", "half_away_from_zero"]
 SerializationFormat: TypeAlias = Literal["binary", "json"]


### PR DESCRIPTION
Notes

- Add a `pcre2` Rust feature: disable it for unsupported CI builds (WASM, Pyodide)
- CI (Benchmark/main): symlink the vendored shared libs so `libpcre2*.so` can be found by Python tests that call `subprocess.check_output(...)`